### PR TITLE
feat: create Map setting page for plateau view 

### DIFF
--- a/plugin/web/components/common/Icon/icons.ts
+++ b/plugin/web/components/common/Icon/icons.ts
@@ -10,10 +10,6 @@ import { ReactComponent as Share } from "./Icons/share.svg";
 import { ReactComponent as Sliders } from "./Icons/sliders.svg";
 import { ReactComponent as DataBase } from "./Icons/dataBase.svg";
 import { ReactComponent as Template } from "./Icons/template.svg";
-import { ReactComponent as MapBing } from "./Icons/mapBing.svg";
-import { ReactComponent as bgmap_darkmatter } from "./Icons/bgmap_darkmatter.svg";
-import { ReactComponent as bgmap_gsi } from "./Icons/bgmap_gsi.svg";
-import { ReactComponent as bgmap_tokyo } from "./Icons/bgmap_tokyo.svg";
 
 export default {
   logo: Logo,
@@ -25,8 +21,4 @@ export default {
   sliders: Sliders,
   dataBase: DataBase,
   template: Template,
-  mapBing: MapBing,
-  bgmap_darkmatter: bgmap_darkmatter,
-  bgmap_gsi: bgmap_gsi,
-  bgmap_tokyo: bgmap_tokyo,
 };

--- a/plugin/web/components/sidebar/Layout/LayoutContent.tsx
+++ b/plugin/web/components/sidebar/Layout/LayoutContent.tsx
@@ -4,6 +4,8 @@ import { styled } from "@web/theme";
 import { Content } from "antd/lib/layout/layout";
 import React, { memo, ReactNode } from "react";
 
+import MapSettingTab from "../tabs/MapSettingTab";
+
 type Props = {
   className?: string;
   children?: ReactNode;
@@ -17,6 +19,7 @@ const LayoutContent: React.FC<Props> = ({ className, children, current }) => {
         {
           shareNprint: <ShareTab />,
           about: <InfoTab />,
+          mapSetting: <MapSettingTab />,
         }[current]
       }
       {children}

--- a/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
+++ b/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
@@ -93,7 +93,9 @@ const MapSettingTab: React.FC = () => {
     </Space>
   );
 };
+
 export default memo(MapSettingTab);
+
 const MapViewSection = styled(Row)`
   display: flex;
   flex-direction: row;
@@ -103,6 +105,7 @@ const MapViewSection = styled(Row)`
   width: 296px;
   height: 103px;
 `;
+
 const MapViewButton = styled(Button)`
   width: 91px;
   height: 29px;
@@ -112,6 +115,7 @@ const MapViewButton = styled(Button)`
   margin: 0px 0px 6px 6px;
   padding: 4px 8px;
 `;
+
 const BaseMapSection = styled(Row)`
   display: flex;
   flex-direction: row;
@@ -121,6 +125,7 @@ const BaseMapSection = styled(Row)`
   width: 326px;
   height: 86px;
 `;
+
 const ImageButton = styled(Radio.Button)`
   margin: 0px 0px 12px 12px;
   border-radius: 4px;
@@ -129,6 +134,7 @@ const ImageButton = styled(Radio.Button)`
   width: 64px;
   height: 64px;
 `;
+
 const RasterMapSlider = styled(Slider)`
   display: flex;
   flex-direction: row;

--- a/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
+++ b/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
@@ -1,6 +1,6 @@
-import Bgmap_darkmatter from "@web/components/common/Icon/icons/bgmap_darkmatter.svg";
-import Bgmap_gsi from "@web/components/common/Icon/icons/bgmap_gsi.svg";
-import Bgmap_tokyo from "@web/components/common/Icon/icons/bgmap_tokyo.svg";
+import bgmap_darkmatter from "@web/components/common/Icon/icons/bgmap_darkmatter.svg";
+import bgmap_gsi from "@web/components/common/Icon/icons/bgmap_gsi.svg";
+import bgmap_tokyo from "@web/components/common/Icon/icons/bgmap_tokyo.svg";
 import mapBing from "@web/components/common/Icon/icons/mapBing.svg";
 import { styled } from "@web/theme";
 import { Checkbox, Divider, Radio, Row, Slider, Space, Typography, Button } from "antd";
@@ -16,17 +16,17 @@ const baseMapData = [
   {
     key: "2",
     title: "National latest photo (seamless)",
-    icon: Bgmap_tokyo,
+    icon: bgmap_tokyo,
   },
   {
     key: "3",
     title: "GSI Maps (light color)",
-    icon: Bgmap_gsi,
+    icon: bgmap_gsi,
   },
   {
     key: "4",
     title: "Dark Matter",
-    icon: Bgmap_darkmatter,
+    icon: bgmap_darkmatter,
   },
 ];
 

--- a/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
+++ b/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
@@ -1,0 +1,140 @@
+import Icon from "@web/components/common/Icon";
+import { styled } from "@web/theme";
+import { Checkbox, Divider, Radio, Row, Slider, Space, Typography, Button } from "antd";
+import React, { memo } from "react";
+
+const mapViewData = ["3D Terrain", "3D smooth", "2D"];
+const baseMapData = [
+  {
+    key: "1",
+    title: "Aerial photography (Bing)",
+    icon: <Icon icon="mapBing" />,
+  },
+  {
+    key: "2",
+    title: "National latest photo (seamless)",
+    icon: <Icon icon="bgmap_tokyo" />,
+  },
+  {
+    key: "3",
+    title: "GSI Maps (light color)",
+    icon: <Icon icon="bgmap_gsi" />,
+  },
+  {
+    key: "4",
+    title: "Dark Matter",
+    icon: <Icon icon="bgmap_darkmatter" />,
+  },
+];
+
+const MapSettingTab: React.FC = () => {
+  const { Text, Title } = Typography;
+  const marks = {
+    0: {
+      style: {
+        color: "#f50",
+      },
+      label: <Text>quality</Text>,
+    },
+    100: {
+      style: {
+        color: "#f50",
+      },
+      label: <Text>performance</Text>,
+    },
+  };
+
+  return (
+    <Space direction="vertical">
+      <Title level={4}>Map setting</Title>
+      <Divider />
+      <Title level={5}>Map View</Title>
+      <MapViewSection>
+        <Radio.Group defaultValue="3D Terrain" buttonStyle="solid">
+          {mapViewData.map(item => (
+            <MapViewButton key={item} value={item} type="primary">
+              <Text style={{ color: " #FFFFFF" }}>{item}</Text>
+            </MapViewButton>
+          ))}
+        </Radio.Group>
+        <Checkbox>
+          <Text>Terrain hides underground features</Text>
+        </Checkbox>
+      </MapViewSection>
+      <Divider />
+      <Title level={5}>Base Map</Title>
+      <BaseMapSection>
+        <Radio.Group defaultValue="1">
+          {baseMapData.map(item => (
+            <ImageButton
+              key={item.key}
+              value={item.key}
+              type="default"
+              icon={item.icon}
+              style={{
+                //  backgroundImage: ` ${item.icon} `,
+                // backgroundImage: "url(" + item.icon + ")",
+                backgroundSize: "cover",
+                backgroundRepeat: "no-repeat",
+              }}
+            />
+          ))}
+        </Radio.Group>
+      </BaseMapSection>
+      <Divider />
+      <Title level={5}>Image optimization</Title>
+      <Checkbox>
+        <Text> use native device resolution</Text>
+      </Checkbox>
+      <Divider />
+      <Title level={5}>Raster map quality</Title>
+      <RasterMapSlider marks={marks} />
+    </Space>
+  );
+};
+export default memo(MapSettingTab);
+const MapViewSection = styled(Row)`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 16px;
+  width: 296px;
+  height: 103px;
+`;
+const MapViewButton = styled(Button)`
+  width: 91px;
+  height: 29px;
+  border-radius: 4px;
+  border-color: #d1d1d1;
+  background: #d1d1d1;
+  margin: 0px 0px 6px 6px;
+  padding: 4px 8px;
+`;
+const BaseMapSection = styled(Row)`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 8px;
+  width: 326px;
+  height: 86px;
+`;
+const ImageButton = styled(Button)`
+  margin: 0px 0px 12px 12px;
+  border-radius: 4px;
+  background: #d1d1d1;
+  padding: 4px 8px;
+  width: 64px;
+  height: 64px;
+`;
+const RasterMapSlider = styled(Slider)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0px;
+  margin-right: 3px;
+  gap: 14px;
+  width: 250px;
+  height: 14px;
+`;

--- a/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
+++ b/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
@@ -46,7 +46,7 @@ const MapSettingTab: React.FC = () => {
       label: <Text>performance</Text>,
     },
   };
-  console.log(mapBing);
+
   return (
     <Space direction="vertical">
       <Title level={4}>Map setting</Title>

--- a/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
+++ b/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
@@ -1,51 +1,37 @@
-import bgmap_darkmatter from "@web/components/common/Icon/icons/bgmap_darkmatter.svg";
-import bgmap_gsi from "@web/components/common/Icon/icons/bgmap_gsi.svg";
-import bgmap_tokyo from "@web/components/common/Icon/icons/bgmap_tokyo.svg";
-import mapBing from "@web/components/common/Icon/icons/mapBing.svg";
+import bgmap_darkmatter from "@web/components/common/Icon/Icons/bgmap_darkmatter.svg";
+import bgmap_gsi from "@web/components/common/Icon/Icons/bgmap_gsi.svg";
+import bgmap_tokyo from "@web/components/common/Icon/Icons/bgmap_tokyo.svg";
+import mapBing from "@web/components/common/Icon/Icons/mapBing.svg";
 import { styled } from "@web/theme";
-import { Checkbox, Divider, Radio, Row, Slider, Space, Typography, Button } from "antd";
+import { Checkbox, Divider, Radio, Row, Space, Typography, Button } from "antd";
 import React, { memo } from "react";
 
-const mapViewData = ["3D Terrain", "3D smooth", "2D"];
-const baseMapData = [
-  {
-    key: "1",
-    title: "Aerial photography (Bing)",
-    icon: mapBing,
-  },
-  {
-    key: "2",
-    title: "National latest photo (seamless)",
-    icon: bgmap_tokyo,
-  },
-  {
-    key: "3",
-    title: "GSI Maps (light color)",
-    icon: bgmap_gsi,
-  },
-  {
-    key: "4",
-    title: "Dark Matter",
-    icon: bgmap_darkmatter,
-  },
-];
-
 const MapSettingTab: React.FC = () => {
+  console.log(bgmap_darkmatter);
   const { Text, Title } = Typography;
-  const marks = {
-    0: {
-      style: {
-        color: "#f50",
-      },
-      label: <Text>quality</Text>,
+  const mapViewData = ["3D Terrain", "3D smooth", "2D"];
+  const baseMapData = [
+    {
+      key: "1",
+      title: "Aerial photography (Bing)",
+      icon: mapBing,
     },
-    100: {
-      style: {
-        color: "#f50",
-      },
-      label: <Text>performance</Text>,
+    {
+      key: "2",
+      title: "National latest photo (seamless)",
+      icon: bgmap_tokyo,
     },
-  };
+    {
+      key: "3",
+      title: "GSI Maps (light color)",
+      icon: bgmap_gsi,
+    },
+    {
+      key: "4",
+      title: "Dark Matter",
+      icon: bgmap_darkmatter,
+    },
+  ];
 
   return (
     <Space direction="vertical">
@@ -82,14 +68,6 @@ const MapSettingTab: React.FC = () => {
           ))}
         </Radio.Group>
       </BaseMapSection>
-      <Divider />
-      <Title level={5}>Image optimization</Title>
-      <Checkbox>
-        <Text> use native device resolution</Text>
-      </Checkbox>
-      <Divider />
-      <Title level={5}>Raster map quality</Title>
-      <RasterMapSlider marks={marks} />
     </Space>
   );
 };
@@ -133,15 +111,4 @@ const ImageButton = styled(Radio.Button)`
   padding: 4px 8px;
   width: 64px;
   height: 64px;
-`;
-
-const RasterMapSlider = styled(Slider)`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 0px;
-  margin-right: 3px;
-  gap: 14px;
-  width: 250px;
-  height: 14px;
 `;

--- a/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
+++ b/plugin/web/components/sidebar/tabs/MapSettingTab.tsx
@@ -1,4 +1,7 @@
-import Icon from "@web/components/common/Icon";
+import Bgmap_darkmatter from "@web/components/common/Icon/icons/bgmap_darkmatter.svg";
+import Bgmap_gsi from "@web/components/common/Icon/icons/bgmap_gsi.svg";
+import Bgmap_tokyo from "@web/components/common/Icon/icons/bgmap_tokyo.svg";
+import mapBing from "@web/components/common/Icon/icons/mapBing.svg";
 import { styled } from "@web/theme";
 import { Checkbox, Divider, Radio, Row, Slider, Space, Typography, Button } from "antd";
 import React, { memo } from "react";
@@ -8,22 +11,22 @@ const baseMapData = [
   {
     key: "1",
     title: "Aerial photography (Bing)",
-    icon: <Icon icon="mapBing" />,
+    icon: mapBing,
   },
   {
     key: "2",
     title: "National latest photo (seamless)",
-    icon: <Icon icon="bgmap_tokyo" />,
+    icon: Bgmap_tokyo,
   },
   {
     key: "3",
     title: "GSI Maps (light color)",
-    icon: <Icon icon="bgmap_gsi" />,
+    icon: Bgmap_gsi,
   },
   {
     key: "4",
     title: "Dark Matter",
-    icon: <Icon icon="bgmap_darkmatter" />,
+    icon: Bgmap_darkmatter,
   },
 ];
 
@@ -43,7 +46,7 @@ const MapSettingTab: React.FC = () => {
       label: <Text>performance</Text>,
     },
   };
-
+  console.log(mapBing);
   return (
     <Space direction="vertical">
       <Title level={4}>Map setting</Title>
@@ -70,10 +73,8 @@ const MapSettingTab: React.FC = () => {
               key={item.key}
               value={item.key}
               type="default"
-              icon={item.icon}
               style={{
-                //  backgroundImage: ` ${item.icon} `,
-                // backgroundImage: "url(" + item.icon + ")",
+                backgroundImage: "url(" + item.icon + ")",
                 backgroundSize: "cover",
                 backgroundRepeat: "no-repeat",
               }}
@@ -120,7 +121,7 @@ const BaseMapSection = styled(Row)`
   width: 326px;
   height: 86px;
 `;
-const ImageButton = styled(Button)`
+const ImageButton = styled(Radio.Button)`
   margin: 0px 0px 12px 12px;
   border-radius: 4px;
   background: #d1d1d1;


### PR DESCRIPTION
### Overview
The main purpose is to create plugins that shows plateau view functionalities, and one of them map setting 
please refer to this https://github.com/eukarya-inc/reearth-plateauview/issues/25
  
### What I've done
1. create the map setting page 
### What I haven't done
### Screenshot
![image](https://user-images.githubusercontent.com/89770889/192833734-edaba5db-45dc-4b33-9a44-afa17ced9753.png)
