### PR TITLE
fix(indexer): zipFS file reading error

### DIFF
--- a/server/searchindex/indexer/fs.go
+++ b/server/searchindex/indexer/fs.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"archive/zip"
+	"bytes"
 	"fmt"
 	"io"
 	"io/fs"
@@ -75,7 +76,15 @@ func (f *ZipFS) Open(name string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return file, nil
+	defer file.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, file)
+	if err != nil {
+		return nil, err
+	}
+
+	return io.NopCloser(buf), nil
 }
 
 type OSOutputFS struct {


### PR DESCRIPTION
It seems that its not possible to access memory of archived file obtain from Open(name) method. In this commit I've simply loaded the file for the time being and provided it to the indexer and I've also made sure that there should be memory leaks.