### PR TITLE
feat(plugin): story telling behavior updates

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -335,6 +335,8 @@ reearth.on("resize", () => {
 reearth.on("pluginmessage", (pluginMessage: PluginMessage) => {
   if (pluginMessage.data.action === "storyShare") {
     reearth.ui.postMessage(pluginMessage.data);
+  } else if (pluginMessage.data.action === "storySaveData") {
+    reearth.ui.postMessage(pluginMessage.data);
   }
 });
 

--- a/plugin/web/extensions/sidebar/core/components/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/hooks.ts
@@ -254,16 +254,22 @@ export default () => {
     [backendURL, backendAccessToken],
   );
 
-  const handleStoryShare = useCallback((story: Story) => {
+  const handleStoryShare = useCallback(() => {
+    setCurrentPage("share");
+  }, []);
+
+  const handleStorySaveData = useCallback((story: Story) => {
+    // save user story
     updateProject(project => {
       const updatedProject: Project = {
         ...project,
-        userStory: story,
+        userStory: {
+          scenes: story.scenes,
+        },
       };
       postMsg({ action: "updateProject", payload: updatedProject });
       return updatedProject;
     });
-    setCurrentPage("share");
   }, []);
 
   const handleInitUserStory = useCallback((story: Story) => {
@@ -294,7 +300,9 @@ export default () => {
       } else if (e.data.action === "triggerHelpOpen") {
         handlePageChange("help");
       } else if (e.data.action === "storyShare") {
-        handleStoryShare(e.data.payload);
+        handleStoryShare();
+      } else if (e.data.action === "storySaveData") {
+        handleStorySaveData(e.data.payload);
       }
     };
     addEventListener("message", eventListenerCallback);

--- a/plugin/web/extensions/sidebar/core/components/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/hooks.ts
@@ -254,10 +254,6 @@ export default () => {
     [backendURL, backendAccessToken],
   );
 
-  const handleStoryShare = useCallback(() => {
-    setCurrentPage("share");
-  }, []);
-
   const handleStorySaveData = useCallback((story: Story) => {
     // save user story
     updateProject(project => {
@@ -300,7 +296,7 @@ export default () => {
       } else if (e.data.action === "triggerHelpOpen") {
         handlePageChange("help");
       } else if (e.data.action === "storyShare") {
-        handleStoryShare();
+        setCurrentPage("share");
       } else if (e.data.action === "storySaveData") {
         handleStorySaveData(e.data.payload);
       }

--- a/plugin/web/extensions/storytelling/core/hooks.ts
+++ b/plugin/web/extensions/storytelling/core/hooks.ts
@@ -106,11 +106,7 @@ export default () => {
 
   // scenes
   const [scenes, setScenes] = useState<Scene[]>([]);
-
-  const sceneCreate = useCallback((scene: Scene) => {
-    setScenes(scenes => [...scenes, scene]);
-    postMsg("sceneEdit", { id: scene.id, title: scene.title, description: scene.description });
-  }, []);
+  const newSceneCamera = useRef<Camera>();
 
   const sceneView = useCallback((camera: Camera) => {
     postMsg("sceneView", camera);
@@ -155,17 +151,10 @@ export default () => {
     });
   }, []);
 
-  const handleSceneCapture = useCallback(
-    (camera: Camera) => {
-      sceneCreate({
-        id: generateId(),
-        title: "",
-        description: "",
-        camera,
-      });
-    },
-    [sceneCreate],
-  );
+  const handleSceneCapture = useCallback((camera: Camera) => {
+    newSceneCamera.current = camera;
+    postMsg("sceneEdit", { id: generateId(), title: "", description: "" });
+  }, []);
 
   const handleSceneRecapture = useCallback(({ camera, id }: { camera: Camera; id: string }) => {
     setScenes(scenes => {
@@ -183,6 +172,11 @@ export default () => {
       if (scene) {
         scene.title = sceneInfo.title;
         scene.description = sceneInfo.description;
+      } else {
+        scenes.push({
+          ...sceneInfo,
+          camera: newSceneCamera.current,
+        });
       }
       return [...scenes];
     });

--- a/plugin/web/extensions/storytelling/core/hooks.ts
+++ b/plugin/web/extensions/storytelling/core/hooks.ts
@@ -191,7 +191,11 @@ export default () => {
   }, []);
 
   const storyShare = useCallback(() => {
-    postMsg("storyShare", {
+    postMsg("storyShare");
+  }, []);
+
+  useEffect(() => {
+    postMsg("storySaveData", {
       scenes: JSON.stringify(scenes),
     });
   }, [scenes]);

--- a/plugin/web/extensions/storytelling/modals/sceneEditor/components/hooks.ts
+++ b/plugin/web/extensions/storytelling/modals/sceneEditor/components/hooks.ts
@@ -1,12 +1,19 @@
 import { postMsg } from "@web/extensions/storytelling/core/utils";
 import EasyMDE from "easymde";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export default () => {
   const storyId = useRef<string>();
   const titleRef = useRef<HTMLInputElement>(null);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const easyMDE = useRef<EasyMDE | null>(null);
+  const [canSave, setCanSave] = useState<boolean>(false);
+
+  const onTitleChange = useCallback(() => {
+    if (titleRef.current) {
+      setCanSave(!!titleRef.current.value);
+    }
+  }, []);
 
   const onCancel = useCallback(() => {
     postMsg("sceneEditorClose");
@@ -33,6 +40,7 @@ export default () => {
     if ((window as any).sceneEdit && titleRef.current && descriptionRef.current) {
       storyId.current = (window as any).sceneEdit.id;
       titleRef.current.value = (window as any).sceneEdit.title;
+      setCanSave(!!titleRef.current.value);
 
       if (easyMDE.current) {
         easyMDE.current.value((window as any).sceneEdit.description);
@@ -50,6 +58,8 @@ export default () => {
   return {
     titleRef,
     descriptionRef,
+    canSave,
+    onTitleChange,
     onCancel,
     onSave,
   };

--- a/plugin/web/extensions/storytelling/modals/sceneEditor/components/index.tsx
+++ b/plugin/web/extensions/storytelling/modals/sceneEditor/components/index.tsx
@@ -5,14 +5,14 @@ import useHooks from "./hooks";
 type Props = {};
 
 const SceneEditor: React.FC<Props> = () => {
-  const { titleRef, descriptionRef, onSave, onCancel } = useHooks();
+  const { titleRef, descriptionRef, canSave, onTitleChange, onSave, onCancel } = useHooks();
 
   return (
     <Wrapper>
-      <TitleInput placeholder="タイトル" ref={titleRef} />
+      <TitleInput placeholder="タイトル" ref={titleRef} onChange={onTitleChange} />
       <ContentInput placeholder="内容" ref={descriptionRef} />
       <Actions>
-        <Button primary onClick={onSave}>
+        <Button primary onClick={onSave} disabled={!canSave}>
           保存
         </Button>
         <Button onClick={onCancel}>キャンセル</Button>
@@ -86,18 +86,20 @@ const Actions = styled.div`
   gap: 12px;
 `;
 
-const Button = styled.div<{ primary?: boolean }>`
+const Button = styled.div<{ primary?: boolean; disabled?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
   height: 29px;
   padding: 4px 12px;
   border-radius: 4px;
-  background-color: ${({ primary }) => (primary ? "#00bebe" : "#d1d1d1")};
+  background-color: ${({ primary, disabled }) =>
+    disabled ? "#d1d1d1" : primary ? "#00bebe" : "#d1d1d1"};
   color: #fff;
   font-size: 14px;
   line-height: 21px;
   cursor: pointer;
+  pointer-events: ${({ disabled }) => (disabled ? "none" : "all")};
 `;
 
 export default SceneEditor;

--- a/plugin/web/extensions/storytelling/types.ts
+++ b/plugin/web/extensions/storytelling/types.ts
@@ -104,9 +104,6 @@ export type StoryCancelPlay = {
 // storytelling -> sidebar
 export type StoryShare = {
   action: "storyShare";
-  payload: {
-    scenes: string;
-  };
 };
 
 export type StorySaveData = {


### PR DESCRIPTION
This is a small PR update some behaviors about story telling:
- Forbidden scene save with empty title.
- Create new scene after save scene info.
- Save story on every edit of scenes. Share only set sidebar to share page.

Tested with [this project.](https://test.reearth.dev/edit/01gpmnf4ah0syavpemp8ywhhsf)