### PR TITLE
fix(plugin): field's move up down functionality

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
@@ -1,5 +1,5 @@
 import AddButton from "@web/extensions/sidebar/core/components/content/common/DatasetCard/AddButton";
-import { swap } from "@web/extensions/sidebar/utils";
+import { generateID, moveItemDown, moveItemUp, removeItem } from "@web/extensions/sidebar/utils";
 import { useCallback, useState } from "react";
 
 import { BaseFieldProps, Cond } from "../types";
@@ -12,10 +12,8 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
 
   const handleMoveUp = useCallback(
     (idx: number) => {
-      if (idx === 0) return;
       updatePointColors(c => {
-        const newPointColors = [...(c ?? [])];
-        swap(newPointColors, idx, idx - 1);
+        const newPointColors = moveItemUp(idx, c) ?? c;
         onUpdate({
           ...value,
           pointColors: newPointColors,
@@ -28,10 +26,8 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
 
   const handleMoveDown = useCallback(
     (idx: number) => {
-      if (pointColors && idx >= pointColors.length - 1) return;
       updatePointColors(c => {
-        const newPointColors = [...(c ?? [])];
-        swap(newPointColors, idx, idx + 1);
+        const newPointColors = moveItemDown(idx, c) ?? c;
         onUpdate({
           ...value,
           pointColors: newPointColors,
@@ -39,14 +35,14 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
         return newPointColors;
       });
     },
-    [value, pointColors, onUpdate],
+    [onUpdate, value],
   );
 
   const handleAdd = useCallback(() => {
     updatePointColors(c => {
       const newPointColor: { condition: Cond<number>; color: string } = {
         condition: {
-          key: Math.random().toString(16).slice(2),
+          key: generateID(),
           operator: "=",
           operand: "width",
           value: 1,
@@ -64,7 +60,7 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
   const handleRemove = useCallback(
     (idx: number) => {
       updatePointColors(c => {
-        const newPointColors = [...(c ?? [])].filter((_, idx2) => idx2 != idx);
+        const newPointColors = removeItem(idx, c) ?? c;
         onUpdate({
           ...value,
           pointColors: newPointColors,

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
@@ -1,5 +1,5 @@
 import AddButton from "@web/extensions/sidebar/core/components/content/common/DatasetCard/AddButton";
-import { array_move } from "@web/extensions/sidebar/utils";
+import { swap } from "@web/extensions/sidebar/utils";
 import { useCallback, useState } from "react";
 
 import { BaseFieldProps, Cond } from "../types";
@@ -15,7 +15,7 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
       if (idx === 0) return;
       updatePointColors(prevPointColors => {
         const copy = [...(prevPointColors ?? [])];
-        array_move(copy, idx, idx - 1);
+        swap(copy, idx, idx - 1);
         onUpdate({
           ...value,
           pointColors: copy,
@@ -31,7 +31,7 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
       if (pointColors && idx >= pointColors.length - 1) return;
       updatePointColors(prevPointColors => {
         const copy = [...(prevPointColors ?? [])];
-        array_move(copy, idx, idx + 1);
+        swap(copy, idx, idx + 1);
         onUpdate({
           ...value,
           pointColors: copy,

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
@@ -10,18 +10,12 @@ import PointColorItem from "./PointColorItem";
 const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, onUpdate }) => {
   const [pointColors, updatePointColors] = useState(value.pointColors);
 
-  const swapElements = (array: any[], index1: number, index2: number) => {
-    const temp = array[index1];
-    array[index1] = array[index2];
-    array[index2] = temp;
-  };
-
   const handleMoveUp = useCallback(
     (idx: number) => {
       if (idx === 0) return;
       updatePointColors(prevPointColors => {
         const copy = [...(prevPointColors ?? [])];
-        swapElements(copy, idx, idx - 1);
+        array_move(copy, idx, idx - 1);
         onUpdate({
           ...value,
           pointColors: copy,
@@ -35,17 +29,14 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
   const handleMoveDown = useCallback(
     (idx: number) => {
       if (pointColors && idx >= pointColors.length - 1) return;
-      updatePointColors(c => {
-        let newPointColors: { condition: Cond<number>; color: string }[] | undefined = undefined;
-        if (c) {
-          newPointColors = c;
-          array_move(newPointColors, idx, idx + 1);
-        }
+      updatePointColors(prevPointColors => {
+        const copy = [...(prevPointColors ?? [])];
+        array_move(copy, idx, idx + 1);
         onUpdate({
           ...value,
-          pointColors: newPointColors,
+          pointColors: copy,
         });
-        return newPointColors;
+        return copy;
       });
     },
     [value, pointColors, onUpdate],
@@ -55,12 +46,12 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
     updatePointColors(c => {
       const newPointColor: { condition: Cond<number>; color: string } = {
         condition: {
-          key: "ARGH",
+          key: Math.random().toString(16).slice(2),
           operator: "=",
-          operand: "AField",
+          operand: "width",
           value: 1,
         },
-        color: "brown",
+        color: "",
       };
       onUpdate({
         ...value,
@@ -72,33 +63,27 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
 
   const handleRemove = useCallback(
     (idx: number) => {
-      updatePointColors(c => {
-        let newPointColors: { condition: Cond<number>; color: string }[] | undefined = undefined;
-        if (c) {
-          newPointColors = c.filter((_, idx2) => idx2 != idx);
-        }
+      updatePointColors(prevState => {
+        const copy = [...(prevState ?? [])].filter((_, idx2) => idx2 != idx);
         onUpdate({
           ...value,
-          pointColors: newPointColors,
+          pointColors: copy,
         });
-        return newPointColors;
+        return copy;
       });
     },
     [value, onUpdate],
   );
 
   const handleItemUpdate = (item: { condition: Cond<number>; color: string }, index: number) => {
-    updatePointColors(c => {
-      let newPointColors: { condition: Cond<number>; color: string }[] | undefined = undefined;
-      if (c) {
-        newPointColors = c;
-        newPointColors.splice(index, 1, item);
-      }
+    updatePointColors(prevState => {
+      const copy = [...(prevState ?? [])];
+      copy.splice(index, 1, item);
       onUpdate({
         ...value,
-        pointColors: newPointColors,
+        pointColors: copy,
       });
-      return newPointColors;
+      return copy;
     });
   };
 

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
@@ -4,26 +4,29 @@ import { useCallback, useState } from "react";
 
 import { BaseFieldProps, Cond } from "../types";
 
-import { ColorField, ConditionField, ItemControls } from "./common";
-import { ButtonWrapper, Item, Wrapper } from "./commonComponents";
+import { ButtonWrapper, Wrapper } from "./commonComponents";
+import PointColorItem from "./PointColorItem";
 
 const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, onUpdate }) => {
   const [pointColors, updatePointColors] = useState(value.pointColors);
 
+  const swapElements = (array: any[], index1: number, index2: number) => {
+    const temp = array[index1];
+    array[index1] = array[index2];
+    array[index2] = temp;
+  };
+
   const handleMoveUp = useCallback(
     (idx: number) => {
       if (idx === 0) return;
-      updatePointColors(c => {
-        let newPointColors: { condition: Cond<number>; color: string }[] | undefined = undefined;
-        if (c) {
-          newPointColors = c;
-          array_move(newPointColors, idx, idx - 1);
-        }
+      updatePointColors(prevPointColors => {
+        const copy = [...(prevPointColors ?? [])];
+        swapElements(copy, idx, idx - 1);
         onUpdate({
           ...value,
-          pointColors: newPointColors,
+          pointColors: copy,
         });
-        return newPointColors;
+        return copy;
       });
     },
     [value, onUpdate],
@@ -84,19 +87,33 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
     [value, onUpdate],
   );
 
+  const handleItemUpdate = (item: { condition: Cond<number>; color: string }, index: number) => {
+    updatePointColors(c => {
+      let newPointColors: { condition: Cond<number>; color: string }[] | undefined = undefined;
+      if (c) {
+        newPointColors = c;
+        newPointColors.splice(index, 1, item);
+      }
+      onUpdate({
+        ...value,
+        pointColors: newPointColors,
+      });
+      return newPointColors;
+    });
+  };
+
   return editMode ? (
     <Wrapper>
-      {value.pointColors?.map((c, idx) => (
-        <Item key={idx}>
-          <ItemControls
-            index={idx}
-            handleMoveDown={handleMoveDown}
-            handleMoveUp={handleMoveUp}
-            handleRemove={handleRemove}
-          />
-          <ConditionField title="if" fieldGap={8} condition={c.condition} />
-          <ColorField title="色" titleWidth={82} color={c.color} />
-        </Item>
+      {pointColors?.map((c, idx) => (
+        <PointColorItem
+          key={idx}
+          index={idx}
+          item={c}
+          handleMoveDown={handleMoveDown}
+          handleMoveUp={handleMoveUp}
+          handleRemove={handleRemove}
+          onItemUpdate={handleItemUpdate}
+        />
       ))}
       <ButtonWrapper>
         <AddButton text="Add Condition" height={24} onClick={handleAdd} />

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColor.tsx
@@ -13,14 +13,14 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
   const handleMoveUp = useCallback(
     (idx: number) => {
       if (idx === 0) return;
-      updatePointColors(prevPointColors => {
-        const copy = [...(prevPointColors ?? [])];
-        swap(copy, idx, idx - 1);
+      updatePointColors(c => {
+        const newPointColors = [...(c ?? [])];
+        swap(newPointColors, idx, idx - 1);
         onUpdate({
           ...value,
-          pointColors: copy,
+          pointColors: newPointColors,
         });
-        return copy;
+        return newPointColors;
       });
     },
     [value, onUpdate],
@@ -29,14 +29,14 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
   const handleMoveDown = useCallback(
     (idx: number) => {
       if (pointColors && idx >= pointColors.length - 1) return;
-      updatePointColors(prevPointColors => {
-        const copy = [...(prevPointColors ?? [])];
-        swap(copy, idx, idx + 1);
+      updatePointColors(c => {
+        const newPointColors = [...(c ?? [])];
+        swap(newPointColors, idx, idx + 1);
         onUpdate({
           ...value,
-          pointColors: copy,
+          pointColors: newPointColors,
         });
-        return copy;
+        return newPointColors;
       });
     },
     [value, pointColors, onUpdate],
@@ -63,27 +63,27 @@ const PointColor: React.FC<BaseFieldProps<"pointColor">> = ({ value, editMode, o
 
   const handleRemove = useCallback(
     (idx: number) => {
-      updatePointColors(prevState => {
-        const copy = [...(prevState ?? [])].filter((_, idx2) => idx2 != idx);
+      updatePointColors(c => {
+        const newPointColors = [...(c ?? [])].filter((_, idx2) => idx2 != idx);
         onUpdate({
           ...value,
-          pointColors: copy,
+          pointColors: newPointColors,
         });
-        return copy;
+        return newPointColors;
       });
     },
     [value, onUpdate],
   );
 
   const handleItemUpdate = (item: { condition: Cond<number>; color: string }, index: number) => {
-    updatePointColors(prevState => {
-      const copy = [...(prevState ?? [])];
-      copy.splice(index, 1, item);
+    updatePointColors(c => {
+      const newPointColors = [...(c ?? [])];
+      newPointColors.splice(index, 1, item);
       onUpdate({
         ...value,
-        pointColors: copy,
+        pointColors: newPointColors,
       });
-      return copy;
+      return newPointColors;
     });
   };
 

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColorItem.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColorItem.tsx
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+
+import { Cond } from "../types";
+
+import { ColorField, ConditionField, ItemControls } from "./common";
+import { Item } from "./commonComponents";
+
+const PointColorItem: React.FC<{
+  index: number;
+  item: { condition: Cond<number>; color: string };
+  handleMoveDown: (index: number) => void;
+  handleMoveUp: (index: number) => void;
+  handleRemove: (index: number) => void;
+  onItemUpdate: (item: { condition: Cond<number>; color: string }, index: number) => void;
+}> = ({ index, item, handleMoveDown, handleMoveUp, handleRemove, onItemUpdate }) => {
+  const handleBackgroundColorUpdate = useCallback(
+    (color: string) => {
+      if (color) {
+        const copy = { ...item, color };
+        onItemUpdate(copy, index);
+      }
+    },
+    [index, item, onItemUpdate],
+  );
+
+  const handleConditionUpdate = useCallback(
+    (condition: Cond<number>) => {
+      console.log(condition);
+      if (condition) {
+        const copy = { ...item, condition };
+        onItemUpdate(copy, index);
+      }
+    },
+    [index, item, onItemUpdate],
+  );
+
+  return (
+    <Item>
+      <ItemControls
+        index={index}
+        handleMoveDown={handleMoveDown}
+        handleMoveUp={handleMoveUp}
+        handleRemove={handleRemove}
+      />
+      <ConditionField
+        title="if"
+        fieldGap={8}
+        condition={item.condition}
+        onChange={handleConditionUpdate}
+      />
+      <ColorField
+        title="色"
+        titleWidth={82}
+        color={item.color}
+        onChange={handleBackgroundColorUpdate}
+      />
+    </Item>
+  );
+};
+
+export default PointColorItem;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColorItem.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointColorItem.tsx
@@ -25,7 +25,6 @@ const PointColorItem: React.FC<{
 
   const handleConditionUpdate = useCallback(
     (condition: Cond<number>) => {
-      console.log(condition);
       if (condition) {
         const copy = { ...item, condition };
         onItemUpdate(copy, index);

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStroke.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStroke.tsx
@@ -1,5 +1,5 @@
 import AddButton from "@web/extensions/sidebar/core/components/content/common/DatasetCard/AddButton";
-import { swap } from "@web/extensions/sidebar/utils";
+import { generateID, moveItemDown, moveItemUp, removeItem } from "@web/extensions/sidebar/utils";
 import { useCallback, useState } from "react";
 
 import { BaseFieldProps, Cond } from "../types";
@@ -14,8 +14,7 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
     (idx: number) => {
       if (idx === 0) return;
       updateItems(c => {
-        const newItems = [...(c ?? [])];
-        swap(newItems, idx, idx - 1);
+        const newItems = moveItemUp(idx, c) ?? c;
         onUpdate({
           ...value,
           items: newItems,
@@ -30,8 +29,7 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
     (idx: number) => {
       if (items && idx >= items.length - 1) return;
       updateItems(c => {
-        const newItems = [...(c ?? [])];
-        swap(newItems, idx, idx + 1);
+        const newItems = moveItemDown(idx, c) ?? c;
         onUpdate({
           ...value,
           items: newItems,
@@ -52,7 +50,7 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
         strokeColor: "",
         strokeWidth: 0,
         condition: {
-          key: Math.random().toString(16).slice(2),
+          key: generateID(),
           operator: "=",
           operand: "width",
           value: 1,
@@ -69,7 +67,7 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
   const handleRemove = useCallback(
     (idx: number) => {
       updateItems(c => {
-        const newItems = [...(c ?? [])].filter((_, idx2) => idx2 != idx);
+        const newItems = removeItem(idx, c) ?? c;
         onUpdate({
           ...value,
           items: newItems,

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStroke.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStroke.tsx
@@ -1,11 +1,11 @@
 import AddButton from "@web/extensions/sidebar/core/components/content/common/DatasetCard/AddButton";
-import { array_move } from "@web/extensions/sidebar/utils";
+import { swap } from "@web/extensions/sidebar/utils";
 import { useCallback, useState } from "react";
 
-import { BaseFieldProps, Cond, Fields } from "../types";
+import { BaseFieldProps, Cond } from "../types";
 
-import { ColorField, ConditionField, Field, ItemControls } from "./common";
-import { ButtonWrapper, Item, TextInput, Wrapper } from "./commonComponents";
+import { ButtonWrapper, Wrapper } from "./commonComponents";
+import PointStrokeItem from "./PointStrokeItem";
 
 const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode, onUpdate }) => {
   const [items, updateItems] = useState(value.items);
@@ -14,12 +14,8 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
     (idx: number) => {
       if (idx === 0) return;
       updateItems(c => {
-        let newItems: Fields["pointStroke"]["items"] = undefined;
-
-        if (c) {
-          newItems = c;
-          array_move(newItems, idx, idx - 1);
-        }
+        const newItems = [...(c ?? [])];
+        swap(newItems, idx, idx - 1);
         onUpdate({
           ...value,
           items: newItems,
@@ -34,11 +30,8 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
     (idx: number) => {
       if (items && idx >= items.length - 1) return;
       updateItems(c => {
-        let newItems: Fields["pointStroke"]["items"] = undefined;
-        if (c) {
-          newItems = c;
-          array_move(newItems, idx, idx + 1);
-        }
+        const newItems = [...(c ?? [])];
+        swap(newItems, idx, idx + 1);
         onUpdate({
           ...value,
           items: newItems,
@@ -56,12 +49,12 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
         strokeWidth: number;
         condition: Cond<string | number>;
       } = {
-        strokeColor: "brown",
-        strokeWidth: 10,
+        strokeColor: "",
+        strokeWidth: 0,
         condition: {
-          key: "ARGH",
+          key: Math.random().toString(16).slice(2),
           operator: "=",
-          operand: "AField",
+          operand: "width",
           value: 1,
         },
       };
@@ -76,10 +69,7 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
   const handleRemove = useCallback(
     (idx: number) => {
       updateItems(c => {
-        let newItems: Fields["pointStroke"]["items"] = undefined;
-        if (c) {
-          newItems = c.filter((_, idx2) => idx2 != idx);
-        }
+        const newItems = [...(c ?? [])].filter((_, idx2) => idx2 != idx);
         onUpdate({
           ...value,
           items: newItems,
@@ -90,20 +80,33 @@ const PointStroke: React.FC<BaseFieldProps<"pointStroke">> = ({ value, editMode,
     [value, onUpdate],
   );
 
+  const handleItemUpdate = (
+    item: { condition: Cond<string | number>; strokeColor: string; strokeWidth: number },
+    index: number,
+  ) => {
+    updateItems(c => {
+      const newItems = [...(c ?? [])];
+      newItems.splice(index, 1, item);
+      onUpdate({
+        ...value,
+        items: newItems,
+      });
+      return newItems;
+    });
+  };
+
   return editMode ? (
     <Wrapper>
-      {value.items?.map((c, idx) => (
-        <Item key={idx}>
-          <ItemControls
-            index={idx}
-            handleMoveDown={handleMoveDown}
-            handleMoveUp={handleMoveUp}
-            handleRemove={handleRemove}
-          />
-          <ConditionField title="if" fieldGap={8} condition={c.condition} />
-          <ColorField title="strokeColor" titleWidth={82} color={c.strokeColor} />
-          <Field title="strokeWidth" titleWidth={82} value={<TextInput value={c.strokeWidth} />} />
-        </Item>
+      {items?.map((c, idx) => (
+        <PointStrokeItem
+          key={idx}
+          index={idx}
+          item={c}
+          handleMoveDown={handleMoveDown}
+          handleMoveUp={handleMoveUp}
+          handleRemove={handleRemove}
+          onItemUpdate={handleItemUpdate}
+        />
       ))}
       <ButtonWrapper>
         <AddButton text="Add Condition" height={24} onClick={handleAdd} />

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStrokeItem.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStrokeItem.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { Cond } from "../types";
 
-import { ColorField, ConditionField, ItemControls } from "./common";
+import { ColorField, ConditionField, ItemControls, NumberField } from "./common";
 import { Item } from "./commonComponents";
 
 const PointStrokeItem: React.FC<{
@@ -36,6 +36,14 @@ const PointStrokeItem: React.FC<{
     [index, item, onItemUpdate],
   );
 
+  const handleStrokeWidthUpdate = useCallback(
+    (strokeWidth: number) => {
+      const copy = { ...item, strokeWidth };
+      onItemUpdate(copy, index);
+    },
+    [index, item, onItemUpdate],
+  );
+
   return (
     <Item>
       <ItemControls
@@ -55,6 +63,12 @@ const PointStrokeItem: React.FC<{
         titleWidth={82}
         color={item.strokeColor}
         onChange={handleStrokeColorUpdate}
+      />
+      <NumberField
+        title="StrokeWidth"
+        titleWidth={82}
+        value={item.strokeWidth}
+        onChange={handleStrokeWidthUpdate}
       />
     </Item>
   );

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStrokeItem.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/PointStrokeItem.tsx
@@ -1,0 +1,63 @@
+import { useCallback } from "react";
+
+import { Cond } from "../types";
+
+import { ColorField, ConditionField, ItemControls } from "./common";
+import { Item } from "./commonComponents";
+
+const PointStrokeItem: React.FC<{
+  index: number;
+  item: { condition: Cond<string | number>; strokeColor: string; strokeWidth: number };
+  handleMoveDown: (index: number) => void;
+  handleMoveUp: (index: number) => void;
+  handleRemove: (index: number) => void;
+  onItemUpdate: (
+    item: { condition: Cond<string | number>; strokeColor: string; strokeWidth: number },
+    index: number,
+  ) => void;
+}> = ({ index, item, handleMoveDown, handleMoveUp, handleRemove, onItemUpdate }) => {
+  const handleStrokeColorUpdate = useCallback(
+    (color: string) => {
+      if (color) {
+        const copy = { ...item, strokeColor: color };
+        onItemUpdate(copy, index);
+      }
+    },
+    [index, item, onItemUpdate],
+  );
+
+  const handleConditionUpdate = useCallback(
+    (condition: Cond<number>) => {
+      if (condition) {
+        const copy = { ...item, condition };
+        onItemUpdate(copy, index);
+      }
+    },
+    [index, item, onItemUpdate],
+  );
+
+  return (
+    <Item>
+      <ItemControls
+        index={index}
+        handleMoveDown={handleMoveDown}
+        handleMoveUp={handleMoveUp}
+        handleRemove={handleRemove}
+      />
+      <ConditionField
+        title="if"
+        fieldGap={8}
+        condition={item.condition}
+        onChange={handleConditionUpdate}
+      />
+      <ColorField
+        title="strokeColor"
+        titleWidth={82}
+        color={item.strokeColor}
+        onChange={handleStrokeColorUpdate}
+      />
+    </Item>
+  );
+};
+
+export default PointStrokeItem;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ColorField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ColorField.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@web/sharedComponents";
 import { styled } from "@web/theme";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 
 import { FieldTitle, FieldValue, FieldWrapper, TextInput } from "../commonComponents";
 
@@ -18,6 +18,11 @@ function isValidColor(color: string) {
 const ColorField: React.FC<Props> = ({ title, titleWidth, color, onChange }) => {
   const [text, setText] = useState(color);
   const [selectedColor, setSelectedColor] = useState(color);
+
+  useEffect(() => {
+    setText(color);
+    setSelectedColor(color);
+  }, [color]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setText(e.target.value);

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
@@ -1,60 +1,60 @@
-import { Icon, Dropdown, Menu } from "@web/sharedComponents";
+import { Select, InputNumber } from "@web/sharedComponents";
 import { styled } from "@web/theme";
 
 import { Cond } from "../../types";
 import { FieldTitle, FieldValue, FieldWrapper } from "../commonComponents";
 
-const operators: { [key: string]: string } = {
-  greater: ">",
-  less: "<",
-  greaterEqual: ">=",
-  lessEqual: "<=",
-  equal: "=",
-};
+const operatorOptions = [
+  { value: "greater", label: ">" },
+  { value: "less", label: "<" },
+  { value: "greaterEqual", label: ">=" },
+  { value: "lessEqual", label: "<=" },
+  { value: "equal", label: "=" },
+];
+
+const operandOptions = [
+  { value: "height", label: "Height" },
+  { value: "Width", label: "Width" },
+];
 
 type Props = {
   title: string;
   fieldGap?: number;
   condition: Cond<any>;
+  onChange?: (condition: Cond<any>) => void;
 };
 
-const ConditionField: React.FC<Props> = ({ title, fieldGap, condition }) => {
-  const menu = (
-    <Menu
-      items={Object.keys(operators).map(op => {
-        return {
-          key: op,
-          label: (
-            <p style={{ margin: 0 }} onClick={() => console.log(op)}>
-              {operators[op]}
-            </p>
-          ),
-        };
-      })}
-    />
-  );
+const ConditionField: React.FC<Props> = ({ title, fieldGap, condition, onChange }) => {
+  const handleOperandChange = (value: any) => {
+    const cond = { ...condition, value };
+    onChange?.(cond);
+  };
+
+  const handleOperatorChange = (value: any) => {
+    const cond = { ...condition, value };
+    onChange?.(cond);
+  };
+
+  const handleValueChange = (value: any) => {
+    const cond = { ...condition, value };
+    onChange?.(cond);
+  };
 
   return (
     <FieldWrapper gap={fieldGap}>
       <FieldTitle>{title}</FieldTitle>
-      <FieldValue>
-        <Dropdown overlay={menu} placement="bottom" trigger={["click"]}>
-          <StyledDropdownButton>
-            <p style={{ margin: 0 }}>{condition.operand}</p>
-            <Icon icon="arrowDownSimple" size={12} />
-          </StyledDropdownButton>
-        </Dropdown>
+      <FieldValue noBorder>
+        <Select options={operandOptions} style={{ width: "100%" }} onChange={handleOperandChange} />
+      </FieldValue>
+      <FieldValue noBorder>
+        <Select
+          options={operatorOptions}
+          style={{ width: "100%" }}
+          onChange={handleOperatorChange}
+        />
       </FieldValue>
       <FieldValue>
-        <Dropdown overlay={menu} placement="bottom" trigger={["click"]}>
-          <StyledDropdownButton>
-            <p style={{ margin: 0 }}>{condition.operator}</p>
-            <Icon icon="arrowDownSimple" size={12} />
-          </StyledDropdownButton>
-        </Dropdown>
-      </FieldValue>
-      <FieldValue>
-        <NumberInput value={condition.value} />
+        <NumberInput value={condition.value} onChange={handleValueChange} />
       </FieldValue>
     </FieldWrapper>
   );
@@ -62,7 +62,7 @@ const ConditionField: React.FC<Props> = ({ title, fieldGap, condition }) => {
 
 export default ConditionField;
 
-const NumberInput = styled.input.attrs({ type: "number" })`
+const NumberInput = styled(InputNumber)`
   height: 100%;
   width: 100%;
   flex: 1;
@@ -73,14 +73,4 @@ const NumberInput = styled.input.attrs({ type: "number" })`
   :focus {
     border: none;
   }
-`;
-
-const StyledDropdownButton = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  align-content: center;
-  padding: 0 16px;
-  cursor: pointer;
 `;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
@@ -1,9 +1,8 @@
-import { Select, InputNumber } from "@web/sharedComponents";
-import { styled } from "@web/theme";
+import { Select } from "@web/sharedComponents";
 import { useEffect, useState } from "react";
 
 import { Cond } from "../../types";
-import { FieldTitle, FieldValue, FieldWrapper } from "../commonComponents";
+import { FieldTitle, FieldValue, FieldWrapper, NumberInput } from "../commonComponents";
 
 const operatorOptions = [
   { value: ">", label: ">" },
@@ -83,16 +82,3 @@ const ConditionField: React.FC<Props> = ({ title, fieldGap, condition, onChange 
 };
 
 export default ConditionField;
-
-const NumberInput = styled(InputNumber)`
-  height: 100%;
-  width: 100%;
-  flex: 1;
-  padding: 0 12px;
-  border: none;
-  outline: none;
-
-  :focus {
-    border: none;
-  }
-`;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
@@ -1,6 +1,6 @@
 import { Select, InputNumber } from "@web/sharedComponents";
 import { styled } from "@web/theme";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Cond } from "../../types";
 import { FieldTitle, FieldValue, FieldWrapper } from "../commonComponents";
@@ -27,6 +27,10 @@ type Props = {
 
 const ConditionField: React.FC<Props> = ({ title, fieldGap, condition, onChange }) => {
   const [cond, setCond] = useState<Cond<any>>(condition);
+
+  useEffect(() => {
+    setCond(condition);
+  }, [condition]);
 
   const handleOperandChange = (operand: any) => {
     setCond(prevCond => {

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
@@ -12,6 +12,7 @@ const operatorOptions = [
   { value: "=", label: "=" },
 ];
 
+// should be updated
 const operandOptions = [
   { value: "height", label: "height" },
   { value: "width", label: "width" },

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/ConditionField.tsx
@@ -1,20 +1,21 @@
 import { Select, InputNumber } from "@web/sharedComponents";
 import { styled } from "@web/theme";
+import { useState } from "react";
 
 import { Cond } from "../../types";
 import { FieldTitle, FieldValue, FieldWrapper } from "../commonComponents";
 
 const operatorOptions = [
-  { value: "greater", label: ">" },
-  { value: "less", label: "<" },
-  { value: "greaterEqual", label: ">=" },
-  { value: "lessEqual", label: "<=" },
-  { value: "equal", label: "=" },
+  { value: ">", label: ">" },
+  { value: "<", label: "<" },
+  { value: ">=", label: ">=" },
+  { value: "<=", label: "<=" },
+  { value: "=", label: "=" },
 ];
 
 const operandOptions = [
-  { value: "height", label: "Height" },
-  { value: "Width", label: "Width" },
+  { value: "height", label: "height" },
+  { value: "width", label: "width" },
 ];
 
 type Props = {
@@ -25,36 +26,53 @@ type Props = {
 };
 
 const ConditionField: React.FC<Props> = ({ title, fieldGap, condition, onChange }) => {
-  const handleOperandChange = (value: any) => {
-    const cond = { ...condition, value };
-    onChange?.(cond);
+  const [cond, setCond] = useState<Cond<any>>(condition);
+
+  const handleOperandChange = (operand: any) => {
+    setCond(prevCond => {
+      const copy = { ...prevCond, operand };
+      onChange?.(copy);
+      return copy;
+    });
   };
 
-  const handleOperatorChange = (value: any) => {
-    const cond = { ...condition, value };
-    onChange?.(cond);
+  const handleOperatorChange = (operator: any) => {
+    setCond(prevCond => {
+      const copy = { ...prevCond, operator };
+      onChange?.(copy);
+      return copy;
+    });
   };
 
   const handleValueChange = (value: any) => {
-    const cond = { ...condition, value };
-    onChange?.(cond);
+    setCond(prevCond => {
+      const copy = { ...prevCond, value };
+      onChange?.(copy);
+      return copy;
+    });
   };
 
   return (
     <FieldWrapper gap={fieldGap}>
       <FieldTitle>{title}</FieldTitle>
       <FieldValue noBorder>
-        <Select options={operandOptions} style={{ width: "100%" }} onChange={handleOperandChange} />
+        <Select
+          options={operandOptions}
+          style={{ width: "100%" }}
+          value={cond.operand}
+          onChange={handleOperandChange}
+        />
       </FieldValue>
       <FieldValue noBorder>
         <Select
           options={operatorOptions}
           style={{ width: "100%" }}
+          value={cond.operator}
           onChange={handleOperatorChange}
         />
       </FieldValue>
       <FieldValue>
-        <NumberInput value={condition.value} onChange={handleValueChange} />
+        <NumberInput value={cond.value} onChange={handleValueChange} />
       </FieldValue>
     </FieldWrapper>
   );

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/NumberField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/NumberField.tsx
@@ -1,0 +1,34 @@
+import { ComponentProps, useEffect, useState } from "react";
+
+import { FieldTitle, FieldValue, FieldWrapper, NumberInput, TextInput } from "../commonComponents";
+
+type Props = {
+  title: string;
+  titleWidth?: number;
+  value?: number;
+  onChange?: (value: number) => void;
+} & ComponentProps<typeof TextInput>;
+
+const NumberField: React.FC<Props> = ({ title, titleWidth, value, onChange, ...props }) => {
+  const [number, setNumber] = useState(value);
+
+  useEffect(() => {
+    setNumber(value);
+  }, [value]);
+
+  const handleChange = (n: number) => {
+    setNumber(n);
+    onChange?.(n);
+  };
+
+  return (
+    <FieldWrapper>
+      <FieldTitle width={titleWidth}>{title}</FieldTitle>
+      <FieldValue>
+        <NumberInput value={number} onChange={handleChange} {...props} />
+      </FieldValue>
+    </FieldWrapper>
+  );
+};
+
+export default NumberField;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/index.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/common/index.ts
@@ -2,8 +2,18 @@ import ColorField from "./ColorField";
 import ConditionField from "./ConditionField";
 import Field from "./Field";
 import ItemControls from "./ItemControls";
+import NumberField from "./NumberField";
 import SelectField from "./SelectField";
 import SwitchField from "./SwitchField";
 import TextField from "./TextField";
 
-export { ColorField, ConditionField, Field, ItemControls, SelectField, SwitchField, TextField };
+export {
+  ColorField,
+  ConditionField,
+  Field,
+  ItemControls,
+  SelectField,
+  SwitchField,
+  TextField,
+  NumberField,
+};

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/commonComponents/index.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/point/commonComponents/index.ts
@@ -1,4 +1,4 @@
-import { Input } from "@web/sharedComponents";
+import { Input, InputNumber } from "@web/sharedComponents";
 import { styled } from "@web/theme";
 
 export const Wrapper = styled.div`
@@ -17,6 +17,19 @@ export const Item = styled.div`
 `;
 
 export const TextInput = styled(Input)`
+  height: 100%;
+  width: 100%;
+  flex: 1;
+  padding: 0 12px;
+  border: none;
+  outline: none;
+
+  :focus {
+    border: none;
+  }
+`;
+
+export const NumberInput = styled(InputNumber)`
   height: 100%;
   width: 100%;
   flex: 1;

--- a/plugin/web/extensions/sidebar/utils/index.ts
+++ b/plugin/web/extensions/sidebar/utils/index.ts
@@ -21,10 +21,6 @@ export function mergeProperty(a: any, b: any) {
   );
 }
 
-export const swap = (arr: any[], index1: number, index2: number) => {
-  [arr[index1], arr[index2]] = [arr[index2], arr[index1]];
-};
-
 export function array_move(arr: any[], old_index: number, new_index: number) {
   if (new_index >= arr.length) {
     let k = new_index - arr.length + 1;
@@ -34,6 +30,34 @@ export function array_move(arr: any[], old_index: number, new_index: number) {
   }
   arr.splice(new_index, 0, arr.splice(old_index, 1)[0]);
 }
+
+export const swap = (arr: any[], index1: number, index2: number) => {
+  [arr[index1], arr[index2]] = [arr[index2], arr[index1]];
+};
+
+export const moveItemUp = (index: number, array?: any[]) => {
+  if (!array || index === 0) return;
+
+  const newArray = [...array];
+  swap(newArray, index, index - 1);
+  return newArray;
+};
+
+export const moveItemDown = (index: number, array?: any[]) => {
+  if (!array || (array && index >= array.length - 1)) return;
+
+  const newArray = [...array];
+  swap(newArray, index, index + 1);
+  return newArray;
+};
+
+export const removeItem = (index: number, array?: any[]) => {
+  if (!array) return;
+
+  const newArray = [...array];
+  newArray.splice(index, 1);
+  return newArray;
+};
 
 export function generateID() {
   return Date.now().toString(36) + Math.random().toString(16).slice(2);

--- a/plugin/web/extensions/sidebar/utils/index.ts
+++ b/plugin/web/extensions/sidebar/utils/index.ts
@@ -21,6 +21,10 @@ export function mergeProperty(a: any, b: any) {
   );
 }
 
+export const swap = (arr: any[], index1: number, index2: number) => {
+  [arr[index1], arr[index2]] = [arr[index2], arr[index1]];
+};
+
 export function array_move(arr: any[], old_index: number, new_index: number) {
   if (new_index >= arr.length) {
     let k = new_index - arr.length + 1;

--- a/plugin/web/sharedComponents/InputNumber/index.tsx
+++ b/plugin/web/sharedComponents/InputNumber/index.tsx
@@ -1,0 +1,3 @@
+import { InputNumber } from "antd";
+
+export default InputNumber;

--- a/plugin/web/sharedComponents/index.ts
+++ b/plugin/web/sharedComponents/index.ts
@@ -9,6 +9,7 @@ import Empty from "@web/sharedComponents/Empty";
 import Form from "@web/sharedComponents/Form";
 import Icon from "@web/sharedComponents/Icon";
 import Input from "@web/sharedComponents/Input";
+import InputNumber from "@web/sharedComponents/InputNumber";
 import { Content, Footer } from "@web/sharedComponents/Layout";
 import message from "@web/sharedComponents/message";
 import Pagination from "@web/sharedComponents/Pagination";
@@ -30,6 +31,7 @@ export {
   Form,
   Icon,
   Input,
+  InputNumber,
   Content,
   Footer,
   message,


### PR DESCRIPTION
Done:
- Implement up and down functionality for `PointColor` and `PointStroke`
- Keep state for common components
- Add `swap`, `moveItemUp`, `moveItemDown` and `removeItem` methods into `util.js`