### PR TITLE
fix(plugin): position error of dataset card arrow

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/index.tsx
@@ -310,6 +310,7 @@ const HeaderContents = styled.div`
   align-items: center;
   height: 46px;
   padding: 0 12px;
+  gap: 12px;
   outline: none;
   cursor: pointer;
 `;
@@ -326,6 +327,7 @@ const LeftMain = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 `;
 
 const Title = styled.p`
@@ -333,7 +335,6 @@ const Title = styled.p`
   font-size: 16px;
   text-overflow: ellipsis;
   overflow: hidden;
-  width: 250px;
   white-space: nowrap;
   user-select: none;
 `;


### PR DESCRIPTION
When scroll bar shows on sidebar, the database card arrow not locate corretly.

Before:
![image](https://user-images.githubusercontent.com/21994748/221095068-8e12c155-19ce-47f7-9e09-bfc76b66b9c8.png)


After:
![image](https://user-images.githubusercontent.com/21994748/221095014-13cf80e2-b1d1-4ed3-ae7d-01742cd8393c.png)
