### PR TITLE
fix(plugin): dropdown / select position fixed when outer scrolling

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/Templates/TemplateCard.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/Templates/TemplateCard.tsx
@@ -93,7 +93,8 @@ const TemplateCard: React.FC<Props> = ({ template, onTemplateSave, onTemplateUpd
               <Dropdown
                 overlay={menuGenerator(menuItems[i].fields)}
                 placement="bottom"
-                trigger={["click"]}>
+                trigger={["click"]}
+                getPopupContainer={trigger => trigger.parentElement ?? document.body}>
                 <div onClick={e => e.stopPropagation()}>
                   <p style={{ margin: 0 }}>{menuItems[i].name}</p>
                 </div>
@@ -225,6 +226,7 @@ const HeaderContents = styled.div`
 `;
 
 const BodyWrapper = styled(AccordionItemPanel)<{ noTransition?: boolean }>`
+  position: relative;
   width: 100%;
   border-radius: 0px 0px 4px 4px;
   background: #fafafa;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/AddButton.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/AddButton.tsx
@@ -28,7 +28,11 @@ const AddButton: React.FC<Props> = ({
   onClick,
 }) => {
   return items ? (
-    <Dropdown overlay={items} placement={direction} trigger={["click"]}>
+    <Dropdown
+      overlay={items}
+      placement={direction}
+      trigger={["click"]}
+      getPopupContainer={trigger => trigger.parentElement ?? document.body}>
       <StyledButton className={className} height={height}>
         <Icon icon="plus" size={14} />
         <Text>{text}</Text>

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingShadow/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingShadow/index.tsx
@@ -23,6 +23,7 @@ const BuildingShadow: React.FC<BaseFieldProps<"buildingShadow">> = ({
       style={{ width: "100%" }}
       value={options.shadow}
       onChange={handleUpdateSelect("shadow")}
+      getPopupContainer={trigger => trigger.parentElement ?? document.body}
       options={[
         {
           value: "disabled",

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/Clipping/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/Clipping/index.tsx
@@ -45,6 +45,7 @@ const Clipping: React.FC<BaseFieldProps<"clipping">> = ({ value, dataID, editMod
         style={{ width: "100%" }}
         value={options.direction}
         onChange={handleUpdateSelect("direction")}
+        getPopupContainer={trigger => trigger.parentElement ?? document.body}
         options={[
           {
             value: "inside",

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Legend/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Legend/index.tsx
@@ -126,7 +126,11 @@ const Legend: React.FC<BaseFieldProps<"legend">> = ({ value, editMode, onUpdate 
       <Field>
         <FieldTitle>スタイル</FieldTitle>
         <FieldValue>
-          <Dropdown overlay={menu} placement="bottom" trigger={["click"]}>
+          <Dropdown
+            overlay={menu}
+            placement="bottom"
+            trigger={["click"]}
+            getPopupContainer={trigger => trigger.parentElement ?? document.body}>
             <StyledDropdownButton>
               <p style={{ margin: 0 }}>{legendStyles[legend.style]}</p>
               <Icon icon="arrowDownSimple" size={12} />
@@ -201,6 +205,7 @@ const FieldTitle = styled(Text)`
 `;
 
 const FieldValue = styled.div`
+  position: relative;
   display: flex;
   border: 1px solid #d9d9d9;
   border-radius: 2px;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchDataset/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchDataset/index.tsx
@@ -76,7 +76,11 @@ const SwitchDataset: React.FC<BaseFieldProps<"switchDataset">> = ({
       <Field>
         <FieldTitle>UIスタイル</FieldTitle>
         <FieldValue>
-          <Dropdown overlay={styleOptions} placement="bottom" trigger={["click"]}>
+          <Dropdown
+            overlay={styleOptions}
+            placement="bottom"
+            trigger={["click"]}
+            getPopupContainer={trigger => trigger.parentElement ?? document.body}>
             <StyledDropdownButton>
               <p style={{ margin: 0 }}>{uiStyles[selectedStyle]}</p>
               <Icon icon="arrowDownSimple" size={12} />
@@ -105,7 +109,11 @@ const SwitchDataset: React.FC<BaseFieldProps<"switchDataset">> = ({
             </Radio.Group>
           ) : (
             <FieldValue>
-              <Dropdown overlay={datasetOptions} placement="bottom" trigger={["click"]}>
+              <Dropdown
+                overlay={datasetOptions}
+                placement="bottom"
+                trigger={["click"]}
+                getPopupContainer={trigger => trigger.parentElement ?? document.body}>
                 <StyledDropdownButton>
                   <p style={{ margin: 0 }}>{selectedDataset.name}</p>
                   <Icon icon="arrowDownSimple" size={12} />
@@ -155,6 +163,7 @@ const FieldTitle = styled(Text)`
 `;
 
 const FieldValue = styled.div`
+  position: relative;
   display: flex;
   border: 1px solid #d9d9d9;
   border-radius: 2px;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchGroup/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchGroup/index.tsx
@@ -81,7 +81,11 @@ const SwitchGroup: React.FC<BaseFieldProps<"switchGroup">> = ({
           <Field>
             <FieldTitle>グループ</FieldTitle>
             <FieldValue>
-              <Dropdown overlay={editGroupMenu(idx)} placement="bottom" trigger={["click"]}>
+              <Dropdown
+                overlay={editGroupMenu(idx)}
+                placement="bottom"
+                trigger={["click"]}
+                getPopupContainer={trigger => trigger.parentElement ?? document.body}>
                 <StyledDropdownButton>
                   <p style={{ margin: 0 }}>
                     {fieldGroups?.find(fg => fg.id === g.fieldGroupID)?.name ?? "-"}
@@ -165,6 +169,7 @@ const FieldTitle = styled(Text)`
 `;
 
 const FieldValue = styled.div`
+  position: relative;
   display: flex;
   border: 1px solid #d9d9d9;
   border-radius: 2px;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/common/ConditionField.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/common/ConditionField.tsx
@@ -65,6 +65,7 @@ const ConditionField: React.FC<Props> = ({ title, fieldGap, condition, onChange 
           style={{ width: "100%" }}
           value={cond.operator}
           onChange={handleOperatorChange}
+          getPopupContainer={trigger => trigger.parentElement ?? document.body}
         />
       </FieldValue>
       <FieldValue>

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/commonComponents/index.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/commonComponents/index.ts
@@ -55,6 +55,7 @@ export const FieldWrapper = styled.div<{ gap?: number }>`
 `;
 
 export const FieldValue = styled.div<{ noBorder?: boolean }>`
+  position: relative;
   display: flex;
   justify-content: start;
   align-items: center;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
@@ -166,6 +166,7 @@ const HeaderContents = styled(AccordionItemButton)`
 `;
 
 const BodyWrapper = styled(AccordionItemPanel)`
+  position: relative;
   border-radius: 0px 0px 4px 4px;
   padding: 12px;
 `;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/index.tsx
@@ -147,7 +147,8 @@ const DatasetCard: React.FC<Props> = ({
               <Dropdown
                 overlay={menuGenerator(menuItems[i].fields)}
                 placement="bottom"
-                trigger={["click"]}>
+                trigger={["click"]}
+                getPopupContainer={trigger => trigger.parentElement ?? document.body}>
                 <div onClick={e => e.stopPropagation()}>
                   <p style={{ margin: 0 }}>{menuItems[i].name}</p>
                 </div>
@@ -325,6 +326,7 @@ const HeaderContents = styled.div`
 `;
 
 const BodyWrapper = styled(AccordionItemPanel)<{ noTransition?: boolean }>`
+  position: relative;
   width: 100%;
   border-radius: 0px 0px 4px 4px;
   background: #fafafa;

--- a/plugin/web/extensions/sidebar/popups/buildingSearch/components/ConditionPanel/Condition.tsx
+++ b/plugin/web/extensions/sidebar/popups/buildingSearch/components/ConditionPanel/Condition.tsx
@@ -34,12 +34,14 @@ const Condition: React.FC<Props> = ({ indexItem, setConditions }) => {
         listHeight={200}
         onChange={handleChange}
         options={options}
+        getPopupContainer={trigger => trigger.parentElement ?? document.body}
       />
     </Wrapper>
   );
 };
 
 const Wrapper = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/plugin/web/extensions/storytelling/core/components/editor/scene.tsx
+++ b/plugin/web/extensions/storytelling/core/components/editor/scene.tsx
@@ -116,7 +116,11 @@ const Scene: React.FC<Props> = ({
       <Header>
         <Title>{title}</Title>
         <ActionsBtn>
-          <Dropdown trigger={["click"]} overlay={menu} placement={"topRight"}>
+          <Dropdown
+            trigger={["click"]}
+            overlay={menu}
+            placement={"topRight"}
+            getPopupContainer={trigger => trigger.parentElement ?? document.body}>
             <Icon icon="dotsThreeVertical" size={24} color={"var(--theme-color)"} />
           </Dropdown>
         </ActionsBtn>
@@ -161,6 +165,7 @@ const Title = styled.div`
 `;
 
 const ActionsBtn = styled.a`
+  position: relative;
   display: flex;
   flex-shrink: 0;
 `;


### PR DESCRIPTION
## Overview

We need to make all dropdown & select follow scroll when scrolling, so please notice when using ANTD `Dropdown` & `Selcet`:

- Add `getPopupContainer={trigger => trigger.parentElement ?? document.body}` to `Dropdown` or `Select`.
- Make sure the tirgger element has a close parent(with in scroll content) with css property`position` setted.
