### PR TITLE
fix(plugin): scrollbar in Data Catalog modal always shows for windows users 

### DIFF
--- a/plugin/web/extensions/sidebar/modals/datacatalog/index.html
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/index.html
@@ -6,8 +6,11 @@
     .root{
         background: #fff;
         border-radius: 8px;
+        height: 100%;   
+        width: 100%;
+        overflow: hidden;
     }
-    html, body, .root {
+    html, body {
         width: 905px;
         height: 590px;
     }


### PR DESCRIPTION
# Overview 
Fix the scrollbar for the datacatalog modal for Windows users 

![image](https://user-images.githubusercontent.com/89770889/222256285-01e054e8-d288-45f1-9b27-2bc5fb604377.png)
