### PR TITLE
fix(plugin): change query name for share URL

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -140,7 +140,7 @@ reearth.on("message", ({ action, payload }: PostMessageProps) => {
     reearth.clientStorage.getAsync("isMobile").then((isMobile: boolean) => {
       reearth.clientStorage.getAsync("draftProject").then((draftProject: Project) => {
         const outBoundPayload = {
-          projectID: reearth.viewport.query.projectID,
+          projectID: reearth.viewport.query.share || reearth.viewport.query.projectID,
           inEditor: reearth.scene.inEditor,
           catalogURL: reearth.widget.property.default?.catalogURL ?? "",
           catalogProjectName: reearth.widget.property.default?.catalogProjectName ?? "",

--- a/plugin/web/extensions/sidebar/core/components/content/Share/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/Share/hooks.ts
@@ -75,16 +75,14 @@ export default ({
         if (resp.status !== 200) {
           messageApi.open({
             type: "error",
-            content: "サバーの問題です。しばらくお待ちしてもう一回して下さい",
+            content: "サーバーに問題が発生しました。しばらく待ってからもう一回試して下さい。",
           });
           if (timer.current) {
             clearTimeout(timer.current);
           }
         } else {
           const project = await resp.json();
-          setPublishedUrl(
-            `${reearthURL}${reearthURL.includes("?") ? "&" : "?"}projectID=${project}`,
-          );
+          setPublishedUrl(`${reearthURL}${reearthURL.includes("?") ? "&" : "?"}share=${project}`);
         }
       }
     }


### PR DESCRIPTION
`?share=xxx` is simpler and easier to understand that the URL is intended to be shared than `?projectID=xxx`