### PR TITLE
fix(plugin): field component name for public and edit mode

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
@@ -111,7 +111,11 @@ const FieldComponent: React.FC<Props> = ({
     };
   }, [groupPopupOpen, onGroupsUpdate]);
 
-  const title = useMemo(() => `${fieldName[field.type]}(${getFieldGroup(field.type)})`, [field]);
+  const title = useMemo(() => fieldName[field.type], [field]);
+  const editModeTitle = useMemo(
+    () => `${title}(${getFieldGroup(field.type)})`,
+    [field.type, title],
+  );
 
   return !editMode && !isActive ? null : field.type === "template" &&
     Field?.Component &&
@@ -142,7 +146,7 @@ const FieldComponent: React.FC<Props> = ({
                     {Field && (
                       <ArrowIcon icon="arrowDown" size={16} direction="right" expanded={expanded} />
                     )}
-                    <Title>{title}</Title>
+                    <Title>{editModeTitle}</Title>
                   </LeftContents>
                   <RightContents>
                     <StyledIcon


### PR DESCRIPTION
Done:
- For the field component names, the added (一般) part should be viewable only in the edit tab 設定 not in the public tab 公開.