### PR TITLE
fix(plugin): show components not belonging in groups 

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
@@ -27,7 +27,7 @@ export default ({
       ? (!dataset.components?.find(c => c.type === "switchGroup") || !dataset.fieldGroups
           ? dataset.components
           : dataset.components.filter(
-              c => (c.group && c.group === selectedGroup) || c.type === "switchGroup",
+              c => (c.group && c.group === selectedGroup) || c.type === "switchGroup" || !c.group,
             )
         )
           ?.filter(c => !(!dataset.config?.data && c.type === "switchDataset"))


### PR DESCRIPTION
## Overview

This PR connects filed component style code with the functionality.

## Test
[Test project](https://test.reearth.dev/edit/01gtxp0y9ee6wx73wbt9k5qp9n)
To test import 避難施設情報（千代田区）
It has 2 groups each group with 2 explanation components, and one explanation component not belonging to any of the two.
also, it has a switch group component, that contains both group 1 and group 2.
The component which does not belong to any group should be always visible.

## Screen Shot
a1, b1 => group 1
a2, b2 => group 2
c (no group)
settings: 
<img width="371" alt="Screenshot 2023-03-07 at 12 29 54 PM" src="https://user-images.githubusercontent.com/105633534/223381551-f522242d-2137-4669-b1e4-c800064ab49a.png">

public:
<img width="361" alt="Screenshot 2023-03-07 at 12 30 07 PM" src="https://user-images.githubusercontent.com/105633534/223381756-5e3af58a-d94f-4bc3-b9ac-ee306995e465.png">

