### PR TITLE
fix(plugin): when the number is deleted it shows a "NaN"

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Realtime.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Realtime.tsx
@@ -50,10 +50,13 @@ const Realtime: React.FC<BaseFieldProps<"realtime">> = ({ value, editMode, onUpd
 
   const handleChangeUpdateTime = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setIntervalValue(parseInt(e.currentTarget.value));
-      startTimer(intervalInSecond);
+      const inputValue = !isNaN(parseFloat(e.currentTarget.value))
+        ? parseFloat(e.currentTarget.value)
+        : 0;
+      setIntervalValue(inputValue);
+      startTimer(inputValue);
     },
-    [intervalInSecond, startTimer],
+    [startTimer],
   );
 
   const propagateRealTimeToLayer = useCallback(() => {
@@ -100,6 +103,7 @@ const Realtime: React.FC<BaseFieldProps<"realtime">> = ({ value, editMode, onUpd
         <FieldTitle>Update time</FieldTitle>
         <FieldValue>
           <TextInput
+            type={"number"}
             readOnly={!enableUpdate}
             value={intervalInSecond}
             onChange={handleChangeUpdateTime}
@@ -156,7 +160,7 @@ const FieldValue = styled.div`
   width: 100%;
 `;
 
-const TextInput = styled.input.attrs({ type: "text" })`
+const TextInput = styled.input`
   height: 100%;
   width: 100%;
   flex: 1;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Realtime.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Realtime.tsx
@@ -50,9 +50,8 @@ const Realtime: React.FC<BaseFieldProps<"realtime">> = ({ value, editMode, onUpd
 
   const handleChangeUpdateTime = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const inputValue = !isNaN(parseFloat(e.currentTarget.value))
-        ? parseFloat(e.currentTarget.value)
-        : 0;
+      const inputValue = parseFloat(e.currentTarget.value);
+      if (isNaN(inputValue)) setTimer("00:00:00");
       setIntervalValue(inputValue);
       startTimer(inputValue);
     },

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Realtime.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Realtime.tsx
@@ -14,7 +14,7 @@ const Realtime: React.FC<BaseFieldProps<"realtime">> = ({ value, editMode, onUpd
     const seconds = Math.floor(interval % 60);
     const minutes = Math.floor((interval / 60) % 60);
     const hours = Math.floor((interval / 60 / 60) % 24);
-    if (interval > 0) {
+    if (interval >= 0) {
       setTimer(
         (hours > 9 ? hours : "0" + hours) +
           ":" +


### PR DESCRIPTION
# The root cause of the issue 
The parseInt function used in the `handleChangeUpdateTime` callback expects a string argument, but when the text field is empty, it returns `NaN `which causes the state to be set to `NaN` as well.