### PR TITLE
Revert "fix(plugin) :  clamp to ground not working"

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -1,6 +1,6 @@
 import { DataCatalogItem } from "@web/extensions/sidebar/core/types";
 import { PostMessageProps, Project, PluginMessage } from "@web/extensions/sidebar/types";
-import { merge, omit } from "lodash";
+import omit from "lodash/omit";
 
 import html from "../dist/web/sidebar/core/index.html?raw";
 import clipVideoHtml from "../dist/web/sidebar/modals/clipVideo/index.html?raw";
@@ -593,7 +593,7 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
         }
       : null,
     ...(overrides !== undefined
-      ? merge({}, defaultOverrides, omit(overrides, "data"))
+      ? omit(overrides, "data")
       : format === "geojson"
       ? {
           marker: {
@@ -629,9 +629,3 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
       : { ...(overrides ?? {}) }),
   };
 }
-const defaultOverrides = {
-  resource: {},
-  marker: { heightReference: "clamp" },
-  polyline: { clampToGround: true },
-  polygon: { clampToGround: true },
-};


### PR DESCRIPTION
This PR caused the `避難施設情報 data and ランドマーク情報 can not bee seen anymore …` BUG. 