### PR TITLE
fix(plugin): use template does not work

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Template.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Template.tsx
@@ -20,13 +20,14 @@ const Template: React.FC<BaseFieldProps<"template">> = ({
 
   const fieldComponents = useMemo(
     () =>
-      (value.components?.length
+      value.components?.length
         ? value.components
-        : hasTemplates
-        ? templates?.find(t => t.id === value.templateID)?.components ?? templates?.[0].components
-        : undefined
-      )?.filter(t => activeIDs?.includes(t.id)),
-    [value.templateID, activeIDs, value.components, templates, hasTemplates],
+        : (hasTemplates
+            ? templates?.find(t => t.id === value.templateID)?.components ??
+              templates?.[0].components
+            : undefined
+          )?.filter(t => activeIDs?.includes(t.id)),
+    [value.templateID, activeIDs, templates, hasTemplates, value.components],
   );
 
   const handleTemplateChange = useCallback(

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
@@ -26,16 +26,26 @@ export default ({
   const [activeComponentIDs, setActiveIDs] = useState<string[] | undefined>();
 
   useEffect(() => {
-    const newActiveIDs = getActiveFieldIDs(dataset.components, selectedGroup, dataset.config?.data);
+    const newActiveIDs = getActiveFieldIDs(
+      dataset.components,
+      selectedGroup,
+      dataset.config?.data,
+      templates,
+    );
 
     if (newActiveIDs !== activeComponentIDs) {
       setActiveIDs(newActiveIDs);
 
       if (!selectedGroup) {
-        setGroup(getDefaultGroup(dataset.components?.filter(c => newActiveIDs?.includes(c.id))));
+        setGroup(
+          getDefaultGroup(
+            dataset.components?.filter(c => newActiveIDs?.includes(c.id)),
+            templates,
+          ),
+        );
       }
     }
-  }, [selectedGroup, dataset.components]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedGroup, dataset.components, templates]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const buildingSearchActive = buildingSearch?.find(b => b.dataID === dataset.dataID)?.active;

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
@@ -37,12 +37,7 @@ export default ({
       setActiveIDs(newActiveIDs);
 
       if (!selectedGroup) {
-        setGroup(
-          getDefaultGroup(
-            dataset.components?.filter(c => newActiveIDs?.includes(c.id)),
-            templates,
-          ),
-        );
+        setGroup(getDefaultGroup(dataset.components?.filter(c => newActiveIDs?.includes(c.id))));
       }
     }
   }, [selectedGroup, dataset.components, templates]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/plugin/web/extensions/sidebar/utils/dataset.ts
+++ b/plugin/web/extensions/sidebar/utils/dataset.ts
@@ -22,20 +22,24 @@ export const getActiveFieldIDs = (
     ?.filter(c => !(!config && c.type === "switchDataset"))
     ?.map(c => c.id);
 
-export const flattenComponents = (components?: FieldComponent[], templates?: Template[]) =>
+export const flattenComponents = (components?: FieldComponent[], baseTemplates?: Template[]) =>
   components?.reduce((a: FieldComponent[], c?: FieldComponent) => {
     if (!c) return a;
     if (c.type === "template") {
-      return [...a, c, ...(templates?.find(t => t.id === c.templateID)?.components ?? [])];
+      return [
+        ...a,
+        c,
+        ...((baseTemplates?.find(t => t.id === c.templateID) ?? c)?.components ?? []),
+      ];
     } else {
       return [...a, c];
     }
   }, []);
 
-export const getDefaultGroup = (components?: FieldComponent[], templates?: Template[]) => {
+export const getDefaultGroup = (components?: FieldComponent[]) => {
   if (!components) return;
 
-  const switchGroupComponents = flattenComponents(components, templates)?.filter(
+  const switchGroupComponents = flattenComponents(components)?.filter(
     c => c.type === "switchGroup",
   ) as SwitchGroup[] | undefined;
 

--- a/plugin/web/extensions/sidebar/utils/dataset.ts
+++ b/plugin/web/extensions/sidebar/utils/dataset.ts
@@ -3,13 +3,15 @@ import {
   FieldComponent,
   SwitchGroup,
 } from "../core/components/content/common/DatasetCard/Field/Fields/types";
+import { Template } from "../core/types";
 
 export const getActiveFieldIDs = (
   components?: FieldComponent[],
   selectedGroup?: string,
   config?: ConfigData[],
+  templates?: Template[],
 ) =>
-  flattenComponents(components)
+  flattenComponents(components, templates)
     ?.filter(
       c =>
         !selectedGroup ||
@@ -20,20 +22,20 @@ export const getActiveFieldIDs = (
     ?.filter(c => !(!config && c.type === "switchDataset"))
     ?.map(c => c.id);
 
-export const flattenComponents = (components?: FieldComponent[]) =>
+export const flattenComponents = (components?: FieldComponent[], templates?: Template[]) =>
   components?.reduce((a: FieldComponent[], c?: FieldComponent) => {
     if (!c) return a;
     if (c.type === "template") {
-      return [...a, c, ...(c.components ?? [])];
+      return [...a, c, ...(templates?.find(t => t.id === c.templateID)?.components ?? [])];
     } else {
       return [...a, c];
     }
   }, []);
 
-export const getDefaultGroup = (components?: FieldComponent[]) => {
+export const getDefaultGroup = (components?: FieldComponent[], templates?: Template[]) => {
   if (!components) return;
 
-  const switchGroupComponents = flattenComponents(components)?.filter(
+  const switchGroupComponents = flattenComponents(components, templates)?.filter(
     c => c.type === "switchGroup",
   ) as SwitchGroup[] | undefined;
 


### PR DESCRIPTION
What i did in this PR:
- `getActiveFieldIDs` now take templates in compute. Before this PR when a dataset which conatins a template added, it can't get the components inside the template (template's components are not saved to backend).
- If there's a template exists, always filter from all template component when switch group.