### PR TITLE
fix(plugin): newly added dataset position

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
@@ -138,9 +138,11 @@ export default ({
       }
 
       updateProject(project => {
+        const datasets = [...project.datasets];
+        datasets.unshift(datasetToAdd);
         const updatedProject: Project = {
           ...project,
-          datasets: [...project.datasets, datasetToAdd],
+          datasets,
         };
 
         postMsg({ action: "updateProject", payload: updatedProject });


### PR DESCRIPTION
Done:
- This PR fixes what has been done in the drag and drop PR that removed the `.reverse()` statement from the `selectedDatasets?.map()` statement in `@web/extensions/sidebar/core/components/content/Selection/index.tsx` file.
  - Before: newly added dataset's position is last.
  - After: newly added dataset's position is first.