### PR TITLE
fix(plugin): set alpha for wms

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -648,6 +648,12 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
           polyline: { clampToGround: true },
           polygon: { clampToGround: true },
         }
+      : format === "wms"
+      ? {
+          raster: {
+            alpha: 0.8,
+          },
+        }
       : { ...(overrides ?? {}) }),
   };
 }


### PR DESCRIPTION
TerriaJS sets default alpha as 0.8 and 1.1 uses it, so we can set default alpha 0.8.

![Screen Shot 2023-03-17 at 12 09 56](https://user-images.githubusercontent.com/34934510/225803143-206d2e8a-0bba-4a2a-a9f3-0d02dcc5ac5a.png)
