### PR TITLE
fix(plugin):the default icon for my data in dataset card should be visible

### DIFF
--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
@@ -69,6 +69,7 @@ const LocalDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedLocalItem }) 
             description:
               "このファイルは今お使いのWebブラウザでのみ閲覧可能です。共有URLを用いて共有するには、公開Webサーバー上のデータを読み込む必要があります。",
             name: filename,
+            visible: true,
             url: url,
             format: setDataFormat(fileType, filename),
           };

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/WebDataTab.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/WebDataTab.tsx
@@ -46,6 +46,7 @@ const WebDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedWebItem }) => {
         "著作権や制約に関する情報などの詳細については、このデータの提供者にお問い合わせください。",
       name: filename,
       url: dataUrl,
+      visible: true,
       format: setDataFormat(fileType, filename),
     };
     const requireLayerName = needsLayerName(dataUrl);


### PR DESCRIPTION
# Overview
 When uplaoding data through the "MyData" screen in dataCatalog modal the icon in dataset card is "Hidden" icon  , we need to make it visible
## What I've done
 
## What I haven't done

## How I tested