### PR TITLE
fix(plugin): infobox update twice on each click

### DIFF
--- a/plugin/src/infobox.ts
+++ b/plugin/src/infobox.ts
@@ -66,10 +66,16 @@ reearth.on("pluginmessage", (pluginMessage: PluginMessage) => {
   }
 });
 
-reearth.on("select", () => {
-  infoboxFieldsFetch();
+let lastSelectedFeatureId: string | undefined;
 
-  reearth.ui.postMessage({
-    action: "setLoading",
-  });
+reearth.on("select", () => {
+  const featureId = reearth.layers.selectedFeature?.id;
+  if (featureId !== lastSelectedFeatureId) {
+    lastSelectedFeatureId = featureId;
+    infoboxFieldsFetch();
+
+    reearth.ui.postMessage({
+      action: "setLoading",
+    });
+  }
 });


### PR DESCRIPTION
## Overview

Check selectedFeature id to avoid fetch twice.

## Screen shot

https://user-images.githubusercontent.com/21994748/227243605-d68a34f7-247a-45da-a90a-62143cb2f375.mp4



## Memo

For now i don't know why this `on select` will trigger twice on each click on building.