### PR TITLE
fix(plugin): enable hide underground by default

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -28,7 +28,7 @@ const defaultProject: Project = {
         height: 2219.7187259974316,
       },
       sceneMode: "3d",
-      depthTestAgainstTerrain: false,
+      depthTestAgainstTerrain: true,
     },
     terrain: {
       terrain: true,

--- a/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
@@ -32,7 +32,7 @@ export const defaultProject: Project = {
         height: 2219.7187259974316,
       },
       sceneMode: "3d",
-      depthTestAgainstTerrain: false,
+      depthTestAgainstTerrain: true,
     },
     terrain: {
       terrain: true,


### PR DESCRIPTION
## Overview

Option `地下を隠す` should be enabled by default.

## Screen shot



https://user-images.githubusercontent.com/21994748/227404083-ed2adc67-6996-4d04-aae7-89a6cf1c7e09.mp4


