### PR TITLE
fix(plugin): support own data in flood model

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingColor/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingColor/hooks.ts
@@ -9,7 +9,7 @@ import { useBuildingColor } from "./useBuildingColor";
 
 type OptionsState = BaseFieldProps<"buildingColor">["value"]["userSettings"];
 
-type RadioItem = { id: string; label: string; featurePropertyName: string };
+type RadioItem = { id: string; label: string; featurePropertyName: string; useOwnData?: boolean };
 
 const useHooks = ({
   value,
@@ -66,11 +66,17 @@ const useHooks = ({
     const handleFloods = (data: any) => {
       const tempFloods: typeof floods = [];
       Object.entries(data?.properties || {}).forEach(([k, v]) => {
-        if (k.endsWith("_浸水ランク") && v && typeof v === "object" && Object.keys(v).length > 0) {
+        if (k.endsWith("_浸水ランク") && v && typeof v === "object") {
+          const useOwnData = !Object.keys(v).length;
+          const featurePropertyName = (() => {
+            if (!useOwnData) return k;
+            return k.split(/[(_（＿]/)[0];
+          })();
           tempFloods.push({
             id: `floods-${tempFloods.length}`,
             label: k.replaceAll("_", " "),
-            featurePropertyName: k,
+            featurePropertyName,
+            useOwnData,
           });
         }
       });

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingColor/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingColor/index.tsx
@@ -32,14 +32,14 @@ const BuildingColor: React.FC<BaseFieldProps<"buildingColor">> = ({
                 <Label>{type.label}</Label>
               </StyledRadio>
             ))}
-            {floods.map(flood => (
-              <StyledRadio key={flood.id} value={flood.id}>
-                <Label>{flood.label}</Label>
-              </StyledRadio>
-            ))}
             {Object.entries(LAND_SLIDE_RISK_FIELD).map(([, val]) => (
               <StyledRadio key={value.id} value={val.id}>
                 <Label>{val.label}</Label>
+              </StyledRadio>
+            ))}
+            {floods.map(flood => (
+              <StyledRadio key={flood.id} value={flood.id}>
+                <Label>{flood.label}</Label>
               </StyledRadio>
             ))}
           </>

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingColor/useBuildingColor.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingColor/useBuildingColor.ts
@@ -1,6 +1,7 @@
 import { getRGBAFromString, RGBA, rgbaToString } from "@web/extensions/sidebar/utils/color";
 import { getOverriddenLayerByDataID } from "@web/extensions/sidebar/utils/getOverriddenLayerByDataID";
 import debounce from "lodash/debounce";
+import pick from "lodash/pick";
 import { RefObject, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { BaseFieldProps } from "../../types";
@@ -17,7 +18,7 @@ export const useBuildingColor = ({
 }: Pick<BaseFieldProps<"buildingColor">, "dataID"> & {
   initialized: boolean;
   options: BaseFieldProps<"buildingColor">["value"]["userSettings"];
-  floods: { id: string; label: string; featurePropertyName: string }[];
+  floods: { id: string; label: string; featurePropertyName: string; useOwnData?: boolean }[];
   onUpdate: (property: any) => void;
 }) => {
   const renderRef = useRef<() => void>();
@@ -53,7 +54,7 @@ export const useBuildingColor = ({
 
 export type State = {
   dataID: string | undefined;
-  floods: { id: string; label: string; featurePropertyName: string }[];
+  floods: { id: string; label: string; featurePropertyName: string; useOwnData?: boolean }[];
   colorType: string;
 };
 
@@ -77,7 +78,11 @@ const renderTileset = (state: State, onUpdateRef: RefObject<(property: any) => v
             (state.colorType as keyof typeof INDEPENDENT_COLOR_TYPE) || "none"
           ]?.map((cond): [string, string] => [cond.condition, cond.color]) ??
           makeSelectedFloodCondition(
-            state.floods?.find(f => f.id === state.colorType)?.featurePropertyName,
+            pick(
+              state.floods?.find(f => f.id === state.colorType),
+              "featurePropertyName",
+              "useOwnData",
+            ) as Pick<(typeof state.floods)[number], "featurePropertyName" | "useOwnData">,
           )
         ).map(([k, v]: [string, string]) => {
           const rgba = getRGBAFromString(v);

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/FloodColor/conditions.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/FloodColor/conditions.ts
@@ -1,6 +1,6 @@
 import { BaseFieldProps } from "../../types";
 import { BuildingColor } from "../types";
-import { equalNumber } from "../utils";
+import { equalNumber, equalString } from "../utils";
 
 type Condition = [condition: string, color: BuildingColor];
 
@@ -8,15 +8,51 @@ const DEFAULT_CONDITION: Condition = ["true", "rgba(209, 82, 209, 0.7)"];
 export const DEFAULT_TRANSPARENCY = 0.7;
 
 const conditionalFloodRank = "rank_code";
+const conditionalFloodRankOrgCode = "rank_org_code";
+const conditionalFloodRankOrg = "rank_org";
 const FLOOD_RANK_CONDITIONS: Condition[] = [
-  [`\${${conditionalFloodRank}} === null`, `rgba(135, 206, 235, ${DEFAULT_TRANSPARENCY})`],
-  [`isNaN(\${${conditionalFloodRank}})`, `rgba(135, 206, 235, ${DEFAULT_TRANSPARENCY})`],
-  [equalNumber(conditionalFloodRank, 0), `rgba(243, 240, 122, ${DEFAULT_TRANSPARENCY})`],
-  [equalNumber(conditionalFloodRank, 1), `rgba(243, 240, 122, ${DEFAULT_TRANSPARENCY})`],
-  [equalNumber(conditionalFloodRank, 2), `rgba(255, 184, 141, ${DEFAULT_TRANSPARENCY})`],
-  [equalNumber(conditionalFloodRank, 3), `rgba(255, 132, 132, ${DEFAULT_TRANSPARENCY})`],
-  [equalNumber(conditionalFloodRank, 4), `rgba(255, 94, 94, ${DEFAULT_TRANSPARENCY})`],
-  [equalNumber(conditionalFloodRank, 5), `rgba(237, 87, 181, ${DEFAULT_TRANSPARENCY})`],
+  [
+    `${equalNumber(conditionalFloodRankOrgCode, 0)} || ${equalString(
+      conditionalFloodRankOrg,
+      "0",
+    )} || ${equalNumber(conditionalFloodRank, 0)}`,
+    `rgba(243, 240, 122, ${DEFAULT_TRANSPARENCY})`,
+  ],
+  [
+    `${equalNumber(conditionalFloodRankOrgCode, 1)} || ${equalString(
+      conditionalFloodRankOrg,
+      "1",
+    )} || ${equalNumber(conditionalFloodRank, 1)}`,
+    `rgba(243, 240, 122, ${DEFAULT_TRANSPARENCY})`,
+  ],
+  [
+    `${equalNumber(conditionalFloodRankOrgCode, 2)} || ${equalString(
+      conditionalFloodRankOrg,
+      "2",
+    )} || ${equalNumber(conditionalFloodRank, 2)}`,
+    `rgba(255, 184, 141, ${DEFAULT_TRANSPARENCY})`,
+  ],
+  [
+    `${equalNumber(conditionalFloodRankOrgCode, 3)} || ${equalString(
+      conditionalFloodRankOrg,
+      "3",
+    )} || ${equalNumber(conditionalFloodRank, 3)}`,
+    `rgba(255, 132, 132, ${DEFAULT_TRANSPARENCY})`,
+  ],
+  [
+    `${equalNumber(conditionalFloodRankOrgCode, 4)} || ${equalString(
+      conditionalFloodRankOrg,
+      "4",
+    )} || ${equalNumber(conditionalFloodRank, 4)}`,
+    `rgba(255, 94, 94, ${DEFAULT_TRANSPARENCY})`,
+  ],
+  [
+    `${equalNumber(conditionalFloodRankOrgCode, 5)} || ${equalString(
+      conditionalFloodRankOrg,
+      "5",
+    )} || ${equalNumber(conditionalFloodRank, 5)}`,
+    `rgba(237, 87, 181, ${DEFAULT_TRANSPARENCY})`,
+  ],
   DEFAULT_CONDITION,
 ];
 

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/utils.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/utils.ts
@@ -11,4 +11,7 @@ export const compareGreaterThan = (conditionalValue: string, num: number) =>
 export const equalString = (prop: string, value: string) => `(${variable(prop)} === "${value}")`;
 export const equalNumber = (prop: string, value: number) => `(${variable(prop)} === ${value})`;
 
+export const stringOrNumber = (v: string | number) =>
+  typeof v === "number" ? v.toString() : `"${v}"`;
+
 export const variable = (prop: string) => `\${${prop}}`;


### PR DESCRIPTION
|Flood model with building model|Tsunami|Takashio|Not own data|
|:--:|:--:|:--:|:--:|
|![Screenshot 2023-03-24 at 22 41 11](https://user-images.githubusercontent.com/34934510/227539487-e5418de8-0dcc-4b36-b22a-343b99bc7ad1.png)|![Screenshot 2023-03-24 at 22 42 20](https://user-images.githubusercontent.com/34934510/227539645-9e842296-ef01-4082-bd3b-ae40cc5a4ec9.png)|![Screenshot 2023-03-24 at 22 43 13](https://user-images.githubusercontent.com/34934510/227539784-dead170c-4b94-45f5-9616-2e326114fb24.png)|![Screenshot 2023-03-24 at 22 43 55](https://user-images.githubusercontent.com/34934510/227539976-77d2fd33-02d2-475a-b0de-63768eee3188.png)|

Not own data is sendai-shi.
Others are kawasaki-shi.