### PR TITLE
fix(plugin): mvt flyTo only works for the first entry

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -341,6 +341,7 @@ reearth.on("message", ({ action, payload }: PostMessageProps) => {
     reearth.ui.postMessage({
       action,
       payload: {
+        dataID,
         layer: {
           id: layer.id,
           data: layer.data,


### PR DESCRIPTION
## Overview

MVT layer needs to get center location by request metadata which use postMessage to transfer data. If it can't get the correct layer data the flyTo can't work.

The event listener expect to receive the exact match result postMessage but actully it can't at most of time since:
- There might be other message transfer at almost the same time, since it's async it's not reliable.
- When `Selection` tab become active, all datasets card got enabled there might be multiple request sent. The results could be matched wrong.

## What i did

- Add dataID to match the layer data and the dataset data.
- Add a timeout.

## Screen shot


https://user-images.githubusercontent.com/21994748/227695747-a2270f94-39b6-4339-9e8a-5e4c091fb1cd.mp4

