### PR TITLE
feat(plugin): add use sunlight option

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -51,6 +51,9 @@ const defaultProject: Project = {
       },
     ],
     atmosphere: { shadows: true },
+    light: {
+      type: "directionalLight",
+    },
   },
   datasets: [],
   userStory: undefined,

--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -52,7 +52,12 @@ const defaultProject: Project = {
     ],
     atmosphere: { shadows: true },
     light: {
-      type: "directionalLight",
+      lightType: "directionalLight",
+      lightColor: "#e5f5ffff",
+      lightIntensity: 10,
+      lightDirectionX: 0.8,
+      lightDirectionY: -0.7,
+      lightDirectionZ: -0.1,
     },
   },
   datasets: [],

--- a/plugin/web/extensions/sidebar/core/components/content/MapSettings/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/MapSettings/hooks.ts
@@ -60,7 +60,7 @@ export default ({ overrides, onOverridesUpdate }: Props) => {
     } = {},
     terrain: { terrain: currentTerrain } = {},
     tiles: currentTiles,
-    light: { type: currentLightType } = {},
+    light: { lightType: currentLightType } = {},
   } = overrides;
 
   const currentView: ViewSelection = useMemo(
@@ -138,12 +138,18 @@ export default ({ overrides, onOverridesUpdate }: Props) => {
       currentLightType === "sunLight"
         ? {
             light: {
-              type: "directionalLight",
+              lightType: "directionalLight",
+              lightColor: "#e5f5ffff",
+              lightIntensity: 10,
+              lightDirectionX: 0.8,
+              lightDirectionY: -0.7,
+              lightDirectionZ: -0.1,
             },
           }
         : {
             light: {
-              type: "sunLight",
+              lightType: "sunLight",
+              lightIntensity: 2,
             },
           },
     );

--- a/plugin/web/extensions/sidebar/core/components/content/MapSettings/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/MapSettings/hooks.ts
@@ -60,6 +60,7 @@ export default ({ overrides, onOverridesUpdate }: Props) => {
     } = {},
     terrain: { terrain: currentTerrain } = {},
     tiles: currentTiles,
+    light: { type: currentLightType } = {},
   } = overrides;
 
   const currentView: ViewSelection = useMemo(
@@ -132,6 +133,22 @@ export default ({ overrides, onOverridesUpdate }: Props) => {
     onOverridesUpdate({ default: { allowEnterGround: !currentAllowEnterGround } });
   }, [currentAllowEnterGround, onOverridesUpdate]);
 
+  const handleUseSunLight = useCallback(() => {
+    onOverridesUpdate(
+      currentLightType === "sunLight"
+        ? {
+            light: {
+              type: "directionalLight",
+            },
+          }
+        : {
+            light: {
+              type: "sunLight",
+            },
+          },
+    );
+  }, [currentLightType, onOverridesUpdate]);
+
   return {
     mapViewData,
     baseMapData,
@@ -139,9 +156,11 @@ export default ({ overrides, onOverridesUpdate }: Props) => {
     currentTiles,
     currentHideUnderground,
     currentAllowEnterGround,
+    currentLightType,
     handleViewChange,
     handleTileChange,
     handleHideUnderGround,
     handleAllowEnterGround,
+    handleUseSunLight,
   };
 };

--- a/plugin/web/extensions/sidebar/core/components/content/MapSettings/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/MapSettings/index.tsx
@@ -20,10 +20,12 @@ const MapSettings: React.FC<Props> = ({ overrides, isMobile, onOverridesUpdate }
     currentTiles,
     currentHideUnderground,
     currentAllowEnterGround,
+    currentLightType,
     handleViewChange,
     handleTileChange,
     handleHideUnderGround,
     handleAllowEnterGround,
+    handleUseSunLight,
   } = useHooks({ overrides, onOverridesUpdate });
 
   return (
@@ -42,12 +44,21 @@ const MapSettings: React.FC<Props> = ({ overrides, isMobile, onOverridesUpdate }
               </MapViewButton>
             ))}
           </ViewWrapper>
-          <Checkbox checked={!!currentHideUnderground} onClick={handleHideUnderGround}>
-            <Text>地下を隠す</Text>
-          </Checkbox>
-          <Checkbox checked={!!currentAllowEnterGround} onClick={handleAllowEnterGround}>
-            <Text>地下に入る</Text>
-          </Checkbox>
+          <CheckboxWrapper>
+            <Checkbox checked={!!currentHideUnderground} onClick={handleHideUnderGround}>
+              <Text>地下を隠す</Text>
+            </Checkbox>
+          </CheckboxWrapper>
+          <CheckboxWrapper>
+            <Checkbox checked={!!currentAllowEnterGround} onClick={handleAllowEnterGround}>
+              <Text>地下に入る</Text>
+            </Checkbox>
+          </CheckboxWrapper>
+          <CheckboxWrapper>
+            <Checkbox checked={currentLightType === "sunLight"} onClick={handleUseSunLight}>
+              <Text>太陽光を利用する</Text>
+            </Checkbox>
+          </CheckboxWrapper>
         </Section>
       </>
       <>
@@ -98,6 +109,13 @@ const ViewWrapper = styled.div`
   display: flex;
   gap: 12px;
   width: 100%;
+`;
+
+const CheckboxWrapper = styled.div`
+  width: 100%;
+  p {
+    margin-bottom: 0;
+  }
 `;
 
 const MapViewButton = styled.button<{ selected?: boolean }>`

--- a/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
@@ -56,7 +56,12 @@ export const defaultProject: Project = {
     ],
     atmosphere: { shadows: true },
     light: {
-      type: "directionalLight",
+      lightType: "directionalLight",
+      lightColor: "#e5f5ffff",
+      lightIntensity: 10,
+      lightDirectionX: 0.8,
+      lightDirectionY: -0.7,
+      lightDirectionZ: -0.1,
     },
   },
   datasets: [],

--- a/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/hooks/projectHooks.ts
@@ -55,6 +55,9 @@ export const defaultProject: Project = {
       },
     ],
     atmosphere: { shadows: true },
+    light: {
+      type: "directionalLight",
+    },
   },
   datasets: [],
   userStory: undefined,

--- a/plugin/web/extensions/sidebar/types.ts
+++ b/plugin/web/extensions/sidebar/types.ts
@@ -115,12 +115,12 @@ export type ReearthApi = {
     stop?: string;
   };
   light?: {
-    type?: "sunLight" | "directionalLight";
-    direction_x?: number;
-    direction_y?: number;
-    direction_z?: number;
-    color?: string;
-    intensity?: number;
+    lightType?: "sunLight" | "directionalLight";
+    lightDirectionX?: number;
+    lightDirectionY?: number;
+    lightDirectionZ?: number;
+    lightColor?: string;
+    lightIntensity?: number;
   };
 };
 

--- a/plugin/web/extensions/sidebar/types.ts
+++ b/plugin/web/extensions/sidebar/types.ts
@@ -114,6 +114,14 @@ export type ReearthApi = {
     start?: string;
     stop?: string;
   };
+  light?: {
+    type?: "sunLight" | "directionalLight";
+    direction_x?: number;
+    direction_y?: number;
+    direction_z?: number;
+    color?: string;
+    intensity?: number;
+  };
 };
 
 type SceneMode = "3d" | "2d";


### PR DESCRIPTION
## Overview

This PR add option `太陽光を利用する` to map settings. Default as unchecked.

- When checked use scene light: sunLight
- When unchecked use scene light: directionalLight

## Screen shot


https://user-images.githubusercontent.com/21994748/227726317-f148f83f-0cbc-46dc-a728-3397975ff616.mp4



