### PR TITLE
fix(plugin): current time inside templates doesn't work

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/CurrentTime.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/CurrentTime.tsx
@@ -86,7 +86,7 @@ const CurrentTime: React.FC<BaseFieldProps<"currentTime">> = ({
       stopTime: options.stopTime,
     });
 
-    onSceneUpdate({
+    onSceneUpdate?.({
       timeline: {
         current: currentTimeStr,
         start: startTimeStr,
@@ -135,7 +135,7 @@ const CurrentTime: React.FC<BaseFieldProps<"currentTime">> = ({
       const now = Date.now();
       const start = new Date(now - 86400000).toISOString();
       const stop = new Date(now).toISOString();
-      onSceneUpdate({
+      onSceneUpdate?.({
         timeline: {
           current: start,
           start,

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Template.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Template.tsx
@@ -17,6 +17,7 @@ const Template: React.FC<BaseFieldProps<"template">> = ({
   configData,
   onUpdate,
   onCurrentGroupUpdate,
+  onSceneUpdate,
 }) => {
   const [fieldComponents, setFieldComponents] = useState<FieldComponentType[] | undefined>();
 
@@ -142,6 +143,7 @@ const Template: React.FC<BaseFieldProps<"template">> = ({
               configData={configData}
               onUpdate={handleFieldUpdate}
               onCurrentGroupUpdate={onCurrentGroupUpdate}
+              onSceneUpdate={onSceneUpdate}
             />
           ))
       )}

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
@@ -32,7 +32,7 @@ export type Props = {
   onMoveDown?: (index: number) => void;
   onGroupsUpdate?: (fieldID: string) => (selectedGroupID?: string | undefined) => void;
   onCurrentGroupUpdate?: (fieldGroupID: string) => void;
-  onSceneUpdate?: (updatedProperties: Partial<ReearthApi>) => void;
+  onSceneUpdate: (updatedProperties: Partial<ReearthApi>) => void;
 };
 
 const getFieldGroup = (field: string) => {
@@ -143,6 +143,7 @@ const FieldComponent: React.FC<Props> = ({
       dataID={dataID}
       onUpdate={onUpdate?.(field.id)}
       onCurrentGroupUpdate={onCurrentGroupUpdate}
+      onSceneUpdate={onSceneUpdate}
     />
   ) : (
     <AccordionComponent

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/index.tsx
@@ -32,7 +32,7 @@ export type Props = {
   onMoveDown?: (index: number) => void;
   onGroupsUpdate?: (fieldID: string) => (selectedGroupID?: string | undefined) => void;
   onCurrentGroupUpdate?: (fieldGroupID: string) => void;
-  onSceneUpdate: (updatedProperties: Partial<ReearthApi>) => void;
+  onSceneUpdate?: (updatedProperties: Partial<ReearthApi>) => void;
 };
 
 const getFieldGroup = (field: string) => {


### PR DESCRIPTION
Done:
- Fixed the bug when current time inside templates doesn't work and cause the system to crash.

How to test:
- Add any dataset
- create a template with two current time component each belongs to a different group
- add a switch group to the template
- try to switch between the two groups