### PR TITLE
fix(plugin):the close button of welcome screen is pushed off the screen in certain phone

### DIFF
--- a/plugin/web/extensions/sidebar/modals/welcomescreen/index.tsx
+++ b/plugin/web/extensions/sidebar/modals/welcomescreen/index.tsx
@@ -83,7 +83,6 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-
   background: rgba(0, 0, 0, 0.7);
 `;
 
@@ -92,6 +91,7 @@ const InnerWrapper = styled.div<{ isMobile?: boolean }>`
   flex-direction: column;
   position: relative;
   width: ${({ isMobile }) => (isMobile ? "318px" : "742px")};
+  max-width: 100%;
 `;
 
 const Text = styled.p<{ weight: number; size: number }>`
@@ -159,6 +159,7 @@ const WelcomeCloseButton = styled(CloseButton)`
   position: absolute;
   right: ${({ isMobile }) => (isMobile ? "-48px" : "-40px")};
   top: ${({ isMobile }) => (isMobile ? "-48px" : "-40px")};
+  flex-grow: 1;
 `;
 
 const VideoCloseButton = styled(CloseButton)`

--- a/plugin/web/extensions/sidebar/modals/welcomescreen/index.tsx
+++ b/plugin/web/extensions/sidebar/modals/welcomescreen/index.tsx
@@ -90,8 +90,8 @@ const InnerWrapper = styled.div<{ isMobile?: boolean }>`
   display: flex;
   flex-direction: column;
   position: relative;
-  width: ${({ isMobile }) => (isMobile ? "318px" : "742px")};
-  max-width: 100%;
+  width: 100%;
+  max-width: ${({ isMobile }) => (isMobile ? "70vw" : "742px")};
 `;
 
 const Text = styled.p<{ weight: number; size: number }>`


### PR DESCRIPTION
 # Overview
 The close button of welcome screen is pushed off the screen in certain phone, this pr is to fix that.
## What I've done
 - Add a new style rule for the InnerWrapper to set a max-width property.
 - Update the style rule for the WelcomeCloseButton to use flex-grow instead of a fixed width.
 This will allow the button to scale with flex and prevent it from being pushed off the screen at certain phone 
## What I haven't done

## How I tested


## Screenshot
![image](https://user-images.githubusercontent.com/89770889/227797840-d9ee78a2-adf2-4f9d-a2c0-bd34d06a092d.png)
![image](https://user-images.githubusercontent.com/89770889/227797868-e3e2555a-435e-4435-8515-10295e6868af.png)
![image](https://user-images.githubusercontent.com/89770889/227797886-de209d41-b337-434c-8a45-98031c310b94.png)
![image](https://user-images.githubusercontent.com/89770889/227797895-3b4f8650-e996-4882-a936-5a56fb55c103.png)
![image](https://user-images.githubusercontent.com/89770889/227797901-241c9461-9836-48b1-a599-cd6372097f1e.png)


