### PR TITLE
fix(plugin): same property `名称` displayed on infobox of htd

### DIFF
--- a/plugin/web/extensions/infobox/core/hooks.ts
+++ b/plugin/web/extensions/infobox/core/hooks.ts
@@ -167,7 +167,7 @@ export default () => {
   }, []);
 
   const actualProperties = useMemo((): [any, string | undefined] => {
-    const rootFields = properties ? getRootFields(properties) : {};
+    const rootFields = properties ? getRootFields(properties, template?.dataType) : {};
     return properties
       ? {
           ...(properties.attributes
@@ -178,7 +178,7 @@ export default () => {
           ...omit(properties, [...Object.keys(rootFields), "attributes"]),
         }
       : undefined;
-  }, [properties]);
+  }, [properties, template?.dataType]);
 
   return {
     inEditor,

--- a/plugin/web/extensions/infobox/core/utils/attributes.ts
+++ b/plugin/web/extensions/infobox/core/utils/attributes.ts
@@ -49,10 +49,12 @@ export function getAttributes(attributes: Json, mode?: "both" | "label" | "key")
   }
 }
 
-export function getRootFields(properties: Properties): any {
+export function getRootFields(properties: Properties, dataType?: string): any {
   return filterObjects({
     gml_id: get(properties, ["attributes", "gml:id"]),
-    名称: get(properties, ["attributes", "gml:name"]),
+    ...(dataType && ["fld", "htd", "tnm", "ifld"].includes(dataType)
+      ? { name: get(properties, ["attributes", "gml:name"]) }
+      : { 名称: get(properties, ["attributes", "gml:name"]) }),
     分類: get(properties, ["attributes", "bldg:class"]),
     用途: get(properties, ["attributes", "bldg:usage", 0]),
     住所: get(properties, ["attributes", "bldg:address"]),


### PR DESCRIPTION
## Overview

The `name` property for `htd` is defined as `name`. When `getRootFields` it uses `名称`(which is good for buildings) so that there become two `name`s.