### PR TITLE
fix(plugin): prevent override data url with undefined

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/hooks/utils.ts
+++ b/plugin/web/extensions/sidebar/core/components/hooks/utils.ts
@@ -65,7 +65,9 @@ export const mergeOverrides = (
           ? components[i].cleanseOverride
           : {
               data: {
-                url: components[i].cleanseOverride.data.url,
+                ...(components[i].cleanseOverride.data.url
+                  ? { url: components[i].cleanseOverride.data.url }
+                  : {}),
                 time: {
                   updateClockOnLoad: true,
                 },


### PR DESCRIPTION
cleanseOverride.data.url with switchDataset is undefined sometimes. Initial url of dataset is overridden with undefined, so some dataset is not working correctly.
I fixed to prevent overriding with undefined `cleanseOverride.data.url`.