### PR TITLE
fix(plugin): building search lookAt with terriain height

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -330,7 +330,21 @@ reearth.on("message", ({ action, payload }: PostMessageProps) => {
       reearth.camera.flyTo(layerID);
     }
   } else if (action === "cameraLookAt") {
-    reearth.camera.lookAt(...payload);
+    if (reearth.scene?.property?.terrain?.terrain) {
+      reearth.scene
+        .sampleTerrainHeight(payload[0].lng, payload[0].lat)
+        .then((terrainHeight: number | undefined) => {
+          reearth.camera.lookAt(
+            {
+              ...payload[0],
+              height: (payload[0].height ?? 0) + (terrainHeight ?? 0),
+            },
+            payload[1],
+          );
+        });
+    } else {
+      reearth.camera.lookAt(...payload);
+    }
   } else if (action === "getCurrentCamera") {
     reearth.ui.postMessage({ action, payload: reearth.camera.position });
     reearth.popup.postMessage({ action, payload: reearth.camera.position });

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/index.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/index.tsx
@@ -73,7 +73,6 @@ const DatasetsPage: React.FC<Props> = ({
       left={
         <DatasetTree
           addedDatasetDataIDs={addedDatasetDataIDs}
-          selectedDataset={selectedDataset}
           catalog={catalog}
           selectedTags={selectedTags}
           filter={filter}

--- a/plugin/web/extensions/sidebar/popups/buildingSearch/components/ConditionPanel/index.tsx
+++ b/plugin/web/extensions/sidebar/popups/buildingSearch/components/ConditionPanel/index.tsx
@@ -30,13 +30,16 @@ const ConditionPanel: React.FC<Props> = ({
             <DatasetName>{dataset?.title}</DatasetName>
           </DatasetInfo>
           <Conditions>
-            {dataset?.indexes.map(indexItem => (
-              <Condition
-                key={indexItem.field}
-                indexItem={indexItem}
-                setConditions={setConditions}
-              />
-            ))}
+            {dataset?.indexes.map(
+              indexItem =>
+                indexItem.values.length > 0 && (
+                  <Condition
+                    key={indexItem.field}
+                    indexItem={indexItem}
+                    setConditions={setConditions}
+                  />
+                ),
+            )}
           </Conditions>
           <ButtonWrapper>
             <Button onClick={conditionApply}>検索</Button>

--- a/plugin/web/extensions/sidebar/popups/buildingSearch/components/hooks.ts
+++ b/plugin/web/extensions/sidebar/popups/buildingSearch/components/hooks.ts
@@ -282,8 +282,8 @@ export default () => {
           {
             lng: Number(selected[0].Longitude),
             lat: Number(selected[0].Latitude),
-            height: Number(selected[0].Height) + 100,
-            range: 200,
+            height: Number(selected[0].Height),
+            range: 300,
           },
           { duration: 2 },
         ],
@@ -292,15 +292,15 @@ export default () => {
   }, [selected]);
 
   useEffect(() => {
-    if (results.length > 0) {
+    if (results.length === 1) {
       postMsg({
         action: "cameraLookAt",
         payload: [
           {
             lng: Number(results[0].Longitude),
             lat: Number(results[0].Latitude),
-            height: Number(results[0].Height) + 100,
-            range: 200,
+            height: Number(results[0].Height),
+            range: 300,
           },
           { duration: 2 },
         ],


### PR DESCRIPTION
## Overviwe

Building search result's height does not consider terrain therefore the lookAt target will be incorrect.

This PR fix:
- lookAt with sampleTerrainHeight added. (require PR merged on reearth)
- Hide search conditions that has no value.
- When search result has multiple items, camera no longer fly to the first result (keep the same behavior as v1.1)

## Screen shot


https://user-images.githubusercontent.com/21994748/227793496-e036cca0-5599-4d98-9e2b-b9583b677a68.mp4

