### PR TITLE
fix(plugin): remove default selected city when opening data catalog

### DIFF
--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/Details.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/Details.tsx
@@ -57,7 +57,7 @@ const DatasetDetails: React.FC<Props> = ({
       )}
     </>
   );
-  return dataset ? (
+  return dataset && "dataID" in dataset ? (
     <DetailsComponent
       dataset={dataset}
       addDisabled={addDisabled(dataset.dataID)}

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/Details.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/Details.tsx
@@ -57,7 +57,7 @@ const DatasetDetails: React.FC<Props> = ({
       )}
     </>
   );
-  return dataset && "dataID" in dataset ? (
+  return dataset ? (
     <DetailsComponent
       dataset={dataset}
       addDisabled={addDisabled(dataset.dataID)}

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/index.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/index.tsx
@@ -64,7 +64,7 @@ const DatasetsPage: React.FC<Props> = ({
   );
 
   const selectedDataset = useMemo(
-    () => catalog?.find(item => item.dataID === selectedDatasetID),
+    () => catalog?.find(item => item.dataID !== undefined && item.dataID === selectedDatasetID),
     [catalog, selectedDatasetID],
   );
 


### PR DESCRIPTION
Done:
- fix: a city is selected by default when data catalog was opened in editor