### PR TITLE
fix(plugin): 3dtiles not showing

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -687,7 +687,7 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
     type: "simple",
     title: dataset.name,
     data: {
-      type: format,
+      type: dataset.config?.data?.[0].type ?? format,
       url: dataset.config?.data?.[0].url ?? dataset.url,
       layers: dataset.config?.data?.[0].layers ?? dataset.layers,
       ...(format === "wms" ? { parameters: { transparent: "true", format: "image/png" } } : {}),


### PR DESCRIPTION
# Overview
sometimes parent dataset doesn't have `format` property 

# Screenshot
<img width="1197" alt="Screenshot 2023-03-28 at 12 23 50 PM" src="https://user-images.githubusercontent.com/105633534/228191596-6042fcd5-0a68-435d-aa92-a13c84c67530.png">
