### PR TITLE
fix(plugin): transparency with style code doesn't work

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/utils.ts
+++ b/plugin/web/extensions/sidebar/core/components/utils.ts
@@ -47,14 +47,6 @@ export const mergeOverrides = (
         ((a as any).userSettings?.updatedAt?.getTime?.() ?? 0) -
         ((b as any).userSettings?.updatedAt?.getTime?.() ?? 0),
     );
-  for (const component of needOrderComponents) {
-    merge(
-      overrides,
-      action === "cleanse"
-        ? cleanseOverrides[component.type]
-        : (component as any).userSettings?.override ?? component.override,
-    );
-  }
 
   for (let i = 0; i < components.length; i++) {
     if ((components[i] as any).userSettings?.updatedAt) {
@@ -84,6 +76,15 @@ export const mergeOverrides = (
       action === "cleanse"
         ? cleanseOverrides[components[i].type]
         : (components[i] as any).userSettings?.override ?? components[i].override,
+    );
+  }
+
+  for (const component of needOrderComponents) {
+    merge(
+      overrides,
+      action === "cleanse"
+        ? cleanseOverrides[component.type]
+        : (component as any).userSettings?.override ?? component.override,
     );
   }
 


### PR DESCRIPTION
`ProcessOverrides` sends in the components that can potentially affect the styling, while It wasn't visible with normal data which doesn't have style code. The order of applying overrides doesn't work in the case of style code because the components also contains a `group` of style code which has the original style.

You can think of component in the code syle-code as collection of original and updated style which comes from transparency change and while merging these styles, till now we were consider the updates before than the original style merge. which should be opposite.