### PR TITLE
fix(plugin): transparency with switch groups with style code

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingTransparency/useBuildingTransparency.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingTransparency/useBuildingTransparency.ts
@@ -59,8 +59,6 @@ const renderTileset = (
   const updateTileset = async () => {
     const overriddenLayer = await getOverriddenLayerByDataID(state.dataID);
     const transparency = (state.transparency ?? 100) / 100;
-    console.log("transparency: ", transparency);
-    console.log("overriddenLayer: ", overriddenLayer);
     const { expression, updatedTransparency } = getTransparencyExpression(
       overriddenLayer,
       transparency,

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingTransparency/useBuildingTransparency.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/3dtiles/BuildingTransparency/useBuildingTransparency.ts
@@ -1,4 +1,4 @@
-import { getRGBAFromString, RGBA, rgbaToString } from "@web/extensions/sidebar/utils/color";
+import { getTransparencyExpression } from "@web/extensions/sidebar/utils/color";
 import { getOverriddenLayerByDataID } from "@web/extensions/sidebar/utils/getOverriddenLayerByDataID";
 import debounce from "lodash/debounce";
 import { MutableRefObject, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
@@ -51,18 +51,6 @@ export type State = {
   isInitializedRef: MutableRefObject<boolean>;
 };
 
-const selectTransparency = (
-  rgba: RGBA | undefined,
-  transparency: number,
-  shouldUseRGBA: boolean,
-) => {
-  if (shouldUseRGBA) {
-    return rgba?.[3] ?? transparency;
-  } else {
-    return transparency;
-  }
-};
-
 const renderTileset = (
   state: State,
   onUpdateRef: RefObject<(property: any) => void>,
@@ -70,41 +58,17 @@ const renderTileset = (
 ) => {
   const updateTileset = async () => {
     const overriddenLayer = await getOverriddenLayerByDataID(state.dataID);
-
-    let transparency = (state.transparency ?? 100) / 100;
-
-    // We can get transparency from RGBA. Because the color is defined as RGBA.
-    const overriddenColor = overriddenLayer?.["3dtiles"]?.color;
-    const defaultRGBA = rgbaToString([255, 255, 255, transparency]);
-    const expression = (() => {
-      if (!overriddenColor) {
-        return defaultRGBA;
-      }
-      if (typeof overriddenColor === "string") {
-        const rgba = getRGBAFromString(overriddenColor);
-        transparency = selectTransparency(rgba, transparency, !state.isInitializedRef.current);
-        return rgba ? rgbaToString([...rgba.slice(0, -1), transparency] as RGBA) : defaultRGBA;
-      }
-
-      const conditions = overriddenColor.expression.conditions.map(([k, v]: [string, string]) => {
-        const rgba = getRGBAFromString(v);
-        if (!rgba) {
-          return [k, defaultRGBA];
-        }
-        transparency = selectTransparency(rgba, transparency, !state.isInitializedRef.current);
-        const composedRGBA = [...rgba.slice(0, -1), transparency] as RGBA;
-        return [k, rgbaToString(composedRGBA)];
-      });
-
-      return {
-        expression: {
-          conditions,
-        },
-      };
-    })();
+    const transparency = (state.transparency ?? 100) / 100;
+    console.log("transparency: ", transparency);
+    console.log("overriddenLayer: ", overriddenLayer);
+    const { expression, updatedTransparency } = getTransparencyExpression(
+      overriddenLayer,
+      transparency,
+      !state.isInitializedRef.current,
+    );
 
     if (!state.isInitializedRef.current) {
-      onChangeTransparency(transparency * 100);
+      onChangeTransparency(updatedTransparency * 100);
       state.isInitializedRef.current = true;
     } else {
       onUpdateRef.current?.({

--- a/plugin/web/extensions/sidebar/core/components/utils.ts
+++ b/plugin/web/extensions/sidebar/core/components/utils.ts
@@ -47,14 +47,6 @@ export const mergeOverrides = (
         ((a as any).userSettings?.updatedAt?.getTime?.() ?? 0) -
         ((b as any).userSettings?.updatedAt?.getTime?.() ?? 0),
     );
-  for (const component of needOrderComponents) {
-    merge(
-      overrides,
-      action === "cleanse"
-        ? cleanseOverrides[component.type]
-        : (component as any).userSettings?.override ?? component.override,
-    );
-  }
 
   for (let i = 0; i < components.length; i++) {
     if ((components[i] as any).userSettings?.updatedAt) {
@@ -84,6 +76,15 @@ export const mergeOverrides = (
       action === "cleanse"
         ? cleanseOverrides[components[i].type]
         : (components[i] as any).userSettings?.override ?? components[i].override,
+    );
+  }
+
+  for (const component of needOrderComponents) {
+    merge(
+      overrides,
+      action === "cleanse"
+        ? cleanseOverrides[component.type]
+        : (component as any).userSettings?.override ?? component.override,
     );
   }
 

--- a/plugin/web/extensions/sidebar/core/components/utils.ts
+++ b/plugin/web/extensions/sidebar/core/components/utils.ts
@@ -1,6 +1,7 @@
 import { RawDataCatalogItem } from "@web/extensions/sidebar/modals/datacatalog/api/api";
 import { cloneDeep, isEqual, merge } from "lodash";
 
+import { getTransparencyExpression } from "../../utils/color";
 import { getDefaultGroup } from "../../utils/dataset";
 import { Data, DataCatalogItem, Template } from "../types";
 
@@ -39,7 +40,6 @@ export const mergeOverrides = (
   }
 
   const overrides = cloneDeep(startingOverride ?? {});
-
   const needOrderComponents = components
     .filter(c => (c as any).userSettings?.updatedAt)
     .sort(
@@ -47,9 +47,21 @@ export const mergeOverrides = (
         ((a as any).userSettings?.updatedAt?.getTime?.() ?? 0) -
         ((b as any).userSettings?.updatedAt?.getTime?.() ?? 0),
     );
+  for (const component of needOrderComponents) {
+    merge(
+      overrides,
+      action === "cleanse"
+        ? cleanseOverrides[component.type]
+        : (component as any).userSettings?.override ?? component.override,
+    );
+  }
+
+  let transparency = 100;
+  let switchGroupExist = false;
 
   for (let i = 0; i < components.length; i++) {
     if ((components[i] as any).userSettings?.updatedAt) {
+      transparency = (components[i] as any)?.userSettings?.transparency ?? 100;
       continue;
     }
     if (components[i].type === "switchDataset") {
@@ -71,6 +83,10 @@ export const mergeOverrides = (
       continue;
     }
 
+    if (components[i].type === "switchGroup") {
+      switchGroupExist = true;
+    }
+
     merge(
       overrides,
       action === "cleanse"
@@ -79,13 +95,14 @@ export const mergeOverrides = (
     );
   }
 
-  for (const component of needOrderComponents) {
-    merge(
-      overrides,
-      action === "cleanse"
-        ? cleanseOverrides[component.type]
-        : (component as any).userSettings?.override ?? component.override,
-    );
+  // This is a temporary solution for switch groups and transparency to work together: @pyshx
+  if (switchGroupExist && transparency != 100) {
+    const { expression } = getTransparencyExpression(overrides, transparency / 100, false);
+    merge(overrides, {
+      "3dtiles": {
+        color: expression,
+      },
+    });
   }
 
   return isEqual(overrides, {}) ? undefined : overrides;

--- a/plugin/web/extensions/sidebar/utils/color.ts
+++ b/plugin/web/extensions/sidebar/utils/color.ts
@@ -52,8 +52,6 @@ export const getTransparencyExpression = (
   transparency: number,
   shouldUseRGBA: boolean,
 ) => {
-  console.log("layer: ", layer);
-  console.log("transparency: ", transparency);
   // We can get transparency from RGBA. Because the color is defined as RGBA.
   const overriddenColor = layer?.["3dtiles"]?.color;
   const defaultRGBA = rgbaToString([255, 255, 255, transparency]);
@@ -75,7 +73,6 @@ export const getTransparencyExpression = (
         return [k, defaultRGBA];
       }
       updatedTransparency = selectTransparency(rgba, transparency, shouldUseRGBA);
-      console.log("updatedTransparency: ", updatedTransparency);
       const composedRGBA = [...rgba.slice(0, -1), updatedTransparency] as RGBA;
       return [k, rgbaToString(composedRGBA)];
     });
@@ -86,10 +83,6 @@ export const getTransparencyExpression = (
       },
     };
   })();
-
-  const tempExpression = expression;
-
-  console.log("expression: ", tempExpression);
 
   return { expression, updatedTransparency };
 };


### PR DESCRIPTION
This PR is a temporary fix for a problem observed with transparency of `3dtiles` with when switch group and style code exist. It also fixes bugs caused by https://github.com/eukarya-inc/reearth-plateauview/pull/370