### PR TITLE
fix(plugin): add exception to highlight with transparency

### DIFF
--- a/plugin/web/extensions/sidebar/utils/color.ts
+++ b/plugin/web/extensions/sidebar/utils/color.ts
@@ -68,6 +68,9 @@ export const getTransparencyExpression = (
     }
 
     const conditions = overriddenColor.expression.conditions.map(([k, v]: [string, string]) => {
+      if (k.includes("${id}")) {
+        return [k, "rgba(255, 0, 0, 1)"];
+      }
       const rgba = getRGBAFromString(v);
       if (!rgba) {
         return [k, defaultRGBA];


### PR DESCRIPTION
This small PR adds an exception to onclick highlighting condition while changing the transparency for layer.