### PR TITLE
feat(plugin): support color string for styling with transparency

### DIFF
--- a/plugin/web/extensions/sidebar/utils/color.ts
+++ b/plugin/web/extensions/sidebar/utils/color.ts
@@ -2,8 +2,29 @@ import tinycolor from "tinycolor2";
 
 export type RGBA = [r: number, g: number, b: number, a: number];
 
-export const getRGBAFromString = (rgbaStr: string | undefined): RGBA | undefined => {
-  const matches = rgbaStr?.match(/rgba\((\d*), *(\d*), *(\d*), *((\d|\.)*)\)/)?.slice(0, -1);
+const colorToRGBA = (hexCode: string): RGBA => {
+  const hex = hexCode.replace("#", "");
+
+  const red = parseInt(hex.substring(0, 2), 16);
+  const green = parseInt(hex.substring(2, 4), 16);
+  const blue = parseInt(hex.substring(4, 6), 16);
+
+  const alpha = hex.length > 6 ? parseFloat((parseInt(hex.substr(6, 2), 16) / 255).toFixed(2)) : 1;
+
+  return [red, green, blue, alpha];
+};
+
+export const getRGBAFromString = (colorStr: string | undefined): RGBA | undefined => {
+  if (!colorStr) {
+    return undefined;
+  }
+
+  if (colorStr.startsWith("color(") && colorStr.endsWith(")")) {
+    const hexCode = colorStr.substring(6, colorStr.length - 1);
+    return colorToRGBA(`#${hexCode}`);
+  }
+
+  const matches = colorStr.match(/rgba\((\d*), *(\d*), *(\d*), *((\d|\.)*)\)/)?.slice(0, -1);
   return matches ? (matches.slice(1).map(m => Number(m)) as RGBA) : undefined;
 };
 
@@ -55,6 +76,7 @@ export const getTransparencyExpression = (
   // We can get transparency from RGBA. Because the color is defined as RGBA.
   const overriddenColor = layer?.["3dtiles"]?.color;
   const defaultRGBA = rgbaToString([255, 255, 255, transparency]);
+  const redRGBA = rgbaToString([255, 0, 0, 1]);
   let updatedTransparency = transparency;
 
   const expression = (() => {
@@ -69,7 +91,7 @@ export const getTransparencyExpression = (
 
     const conditions = overriddenColor.expression.conditions.map(([k, v]: [string, string]) => {
       if (k.includes("${id}")) {
-        return [k, "rgba(255, 0, 0, 1)"];
+        return [k, redRGBA];
       }
       const rgba = getRGBAFromString(v);
       if (!rgba) {

--- a/plugin/web/extensions/sidebar/utils/color.ts
+++ b/plugin/web/extensions/sidebar/utils/color.ts
@@ -2,16 +2,19 @@ import tinycolor from "tinycolor2";
 
 export type RGBA = [r: number, g: number, b: number, a: number];
 
-const colorToRGBA = (hexCode: string): RGBA => {
-  const hex = hexCode.replace("#", "");
+export const rrggbbaaHexMatcher = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?$/i;
+export const rgbaMatcher = /rgba\((\d*), *(\d*), *(\d*), *((\d|\.)*)\)/;
 
-  const red = parseInt(hex.substring(0, 2), 16);
-  const green = parseInt(hex.substring(2, 4), 16);
-  const blue = parseInt(hex.substring(4, 6), 16);
-
-  const alpha = hex.length > 6 ? parseFloat((parseInt(hex.substr(6, 2), 16) / 255).toFixed(2)) : 1;
-
-  return [red, green, blue, alpha];
+const colorToRGBA = (hexCode: string): RGBA | undefined => {
+  const matches = rrggbbaaHexMatcher.exec(hexCode);
+  if (matches !== null) {
+    const red = parseInt(matches[1], 16);
+    const green = parseInt(matches[2], 16);
+    const blue = parseInt(matches[3], 16);
+    const alpha = matches[4] !== undefined ? parseInt(matches[4], 16) / 255 : 1;
+    return [red, green, blue, alpha];
+  }
+  return undefined;
 };
 
 export const getRGBAFromString = (colorStr: string | undefined): RGBA | undefined => {
@@ -19,12 +22,15 @@ export const getRGBAFromString = (colorStr: string | undefined): RGBA | undefine
     return undefined;
   }
 
-  if (colorStr.startsWith("color(") && colorStr.endsWith(")")) {
-    const hexCode = colorStr.substring(6, colorStr.length - 1);
-    return colorToRGBA(`#${hexCode}`);
+  if (
+    (colorStr.startsWith("color('") && colorStr.endsWith("')")) ||
+    (colorStr.startsWith('color("') && colorStr.endsWith('")'))
+  ) {
+    const hexCode = colorStr.substring(7, colorStr.length - 2);
+    return colorToRGBA(`${hexCode}`);
   }
 
-  const matches = colorStr.match(/rgba\((\d*), *(\d*), *(\d*), *((\d|\.)*)\)/)?.slice(0, -1);
+  const matches = colorStr.match(rgbaMatcher)?.slice(0, -1);
   return matches ? (matches.slice(1).map(m => Number(m)) as RGBA) : undefined;
 };
 


### PR DESCRIPTION
This PR adds support for `color(hexcode)` compatible for transparency.