### PR TITLE
fix(plugin): data catalog trees effect each other

### DIFF
--- a/plugin/web/extensions/sidebar/modals/datacatalog/api/api.test.ts
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/api/api.test.ts
@@ -58,25 +58,25 @@ test("modifyDataCatalog", () => {
 test("getRawDataCatalogTree by cities", () => {
   expect(getRawDataCatalogTree(dataCatalog, "city", "")).toEqual([
     {
-      id: "node-0",
+      id: "city-node-0",
       name: "全球データ",
       children: [zenkyuData],
     },
     {
-      id: "node-2",
+      id: "city-node-2",
       name: "東京都",
       children: [
         {
-          id: "node-3",
+          id: "city-node-3",
           name: "東京都23区",
           children: [
             {
-              id: "node-4",
+              id: "city-node-4",
               name: "千代田区",
               children: [chiyodakuBldg, chiyodakuShelter],
             },
             {
-              id: "node-7",
+              id: "city-node-7",
               name: "世田谷区",
               children: [setagayakuBldg, setagayakuShelter],
             },
@@ -84,28 +84,28 @@ test("getRawDataCatalogTree by cities", () => {
           ],
         },
         {
-          id: "node-11",
+          id: "city-node-11",
           name: "八王子市",
           children: [hachiojiBldg, hachiojiLandmark],
         },
         {
-          id: "node-14",
+          id: "city-node-14",
           name: "ユースケース",
           children: [tokyoUsecase],
         },
       ],
     },
     {
-      id: "node-16",
+      id: "city-node-16",
       name: "栃木県",
       children: [
         {
-          id: "node-17",
+          id: "city-node-17",
           name: "宇都宮市",
           children: [
             utsunomiyashiBldg,
             {
-              id: "node-19",
+              id: "city-node-19",
               name: "都市計画決定情報モデル",
               children: [utsunomiyashiUseDictrict],
             },
@@ -119,15 +119,15 @@ test("getRawDataCatalogTree by cities", () => {
 test("getRawDataCatalogTree by types", () => {
   expect(getRawDataCatalogTree(dataCatalog, "type", "")).toEqual([
     {
-      id: "node-0",
+      id: "type-node-0",
       name: "建築物モデル",
       children: [
         {
-          id: "node-1",
+          id: "type-node-1",
           name: "東京都",
           children: [
             {
-              id: "node-2",
+              id: "type-node-2",
               name: "東京都23区",
               children: [chiyodakuBldgByType, setagayakuBldgByType],
             },
@@ -135,22 +135,22 @@ test("getRawDataCatalogTree by types", () => {
           ],
         },
         {
-          id: "node-6",
+          id: "type-node-6",
           name: "栃木県",
           children: [utsunomiyashiBldgByType],
         },
       ],
     },
     {
-      id: "node-8",
+      id: "type-node-8",
       name: "都市計画決定情報モデル",
       children: [
         {
-          id: "node-9",
+          id: "type-node-9",
           name: "栃木県",
           children: [
             {
-              id: "node-10",
+              id: "type-node-10",
               name: "宇都宮市",
               children: [utsunomiyashiUseDictrictByType],
             },
@@ -159,15 +159,15 @@ test("getRawDataCatalogTree by types", () => {
       ],
     },
     {
-      id: "node-12",
+      id: "type-node-12",
       name: "避難施設情報",
       children: [
         {
-          id: "node-13",
+          id: "type-node-13",
           name: "東京都",
           children: [
             {
-              id: "node-14",
+              id: "type-node-14",
               name: "東京都23区",
               children: [chiyodakuShelterByType, setagayakuShelterByType],
             },
@@ -176,38 +176,38 @@ test("getRawDataCatalogTree by types", () => {
       ],
     },
     {
-      id: "node-17",
+      id: "type-node-17",
       name: "ランドマーク情報",
       children: [
         {
-          id: "node-18",
+          id: "type-node-18",
           name: "東京都",
           children: [hachiojiLandmarkByType],
         },
       ],
     },
     {
-      id: "node-20",
+      id: "type-node-20",
       name: "公園情報",
       children: [
         {
-          id: "node-21",
+          id: "type-node-21",
           name: "東京都",
           children: [tokyo23kuParkByType],
         },
       ],
     },
     {
-      id: "node-23",
+      id: "type-node-23",
       name: "ユースケース",
       children: [
         {
-          id: "node-24",
+          id: "type-node-24",
           name: "全球データ",
           children: [zenkyuDataByType],
         },
         {
-          id: "node-26",
+          id: "type-node-26",
           name: "東京都",
           children: [tokyoUsecaseByType],
         },
@@ -219,15 +219,15 @@ test("getRawDataCatalogTree by types", () => {
 test("getRawDataCatalogTree filter", () => {
   expect(getRawDataCatalogTree(dataCatalog, "type", "世田谷")).toEqual([
     {
-      id: "node-0",
+      id: "type-node-0",
       name: "建築物モデル",
       children: [
         {
-          id: "node-1",
+          id: "type-node-1",
           name: "東京都",
           children: [
             {
-              id: "node-2",
+              id: "type-node-2",
               name: "東京都23区",
               children: [setagayakuBldgByType],
             },
@@ -236,15 +236,15 @@ test("getRawDataCatalogTree filter", () => {
       ],
     },
     {
-      id: "node-4",
+      id: "type-node-4",
       name: "避難施設情報",
       children: [
         {
-          id: "node-5",
+          id: "type-node-5",
           name: "東京都",
           children: [
             {
-              id: "node-6",
+              id: "type-node-6",
               name: "東京都23区",
               children: [setagayakuShelterByType],
             },

--- a/plugin/web/extensions/sidebar/modals/datacatalog/api/api.ts
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/api/api.ts
@@ -117,7 +117,7 @@ export function getRawDataCatalogTree(
   q?: string | undefined,
 ): (RawDataCatalogGroup | RawDataCatalogItem)[] {
   return mapTree(
-    makeTree(sortInternal(items, groupBy, q)),
+    makeTree(sortInternal(items, groupBy, q), groupBy),
     (item): RawDataCatalogGroup | RawDataCatalogItem =>
       item.item ?? {
         id: item.id,

--- a/plugin/web/extensions/sidebar/modals/datacatalog/api/utils.ts
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/api/utils.ts
@@ -1,6 +1,6 @@
 export type Tree<T> = { id: string; name: string; children?: Tree<T>[]; item?: T };
 
-export function makeTree<T extends { path: string[] }>(items: T[]): Tree<T>[] {
+export function makeTree<T extends { path: string[] }>(items: T[], prefix?: string): Tree<T>[] {
   type R = { result: Tree<T>[]; map: Record<string, R> };
   const result: Tree<T>[] = [];
   const level: R = { result, map: {} };
@@ -14,7 +14,7 @@ export function makeTree<T extends { path: string[] }>(items: T[]): Tree<T>[] {
         const list: R = { result: [], map: {} };
         r.map[name] = list;
 
-        const id = `node-${idCounter++}`;
+        const id = `${prefix ? prefix + "-" : ""}node-${idCounter++}`;
         r.result.push({ id, name, ...(last ? { item } : { children: list.result }) });
       }
       return r.map[name];


### PR DESCRIPTION
## Overview

There're two (or three) trees in data catalog, their item ids are like `node-${index}` so there're different items with the same id between trees. When user fold/unfold any folder, the items with the same id will also be considered as fold/unfold.

The most obvious example is the first item of the two trees. They both have id `node-0` and each time click on one of them, the other also got effected.

This PR adds an optinal prefix to `makeTree` and use `groupBy` as the prefix so that tree items has unique id now.