### PR TITLE
fix(plugin): some dropdown arrows are not vertical aligned

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Legend/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/Legend/index.tsx
@@ -133,7 +133,7 @@ const Legend: React.FC<BaseFieldProps<"legend">> = ({ value, editMode, onUpdate 
             getPopupContainer={trigger => trigger.parentElement ?? document.body}>
             <StyledDropdownButton>
               <p style={{ margin: 0 }}>{legendStyles[legend.style]}</p>
-              <Icon icon="arrowDownSimple" size={12} />
+              <StyledIcon icon="arrowDownSimple" size={12} />
             </StyledDropdownButton>
           </Dropdown>
         </FieldValue>
@@ -187,6 +187,10 @@ const StyledDropdownButton = styled.div`
   align-content: center;
   padding: 0 16px;
   cursor: pointer;
+`;
+
+const StyledIcon = styled(Icon)`
+  font-size: 0;
 `;
 
 const Text = styled.p`

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/LegendGradient/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/LegendGradient/index.tsx
@@ -53,7 +53,7 @@ const LegendGradient: React.FC<BaseFieldProps<"legendGradient">> = ({
             getPopupContainer={trigger => trigger.parentElement ?? document.body}>
             <StyledDropdownButton>
               <p style={{ margin: 0 }}>{legendStyles[`${legendGradient.style}`]}</p>
-              <Icon icon="arrowDownSimple" size={12} />
+              <StyledIcon icon="arrowDownSimple" size={12} />
             </StyledDropdownButton>
           </Dropdown>
         </FieldValue>
@@ -117,6 +117,10 @@ const StyledDropdownButton = styled.div`
   align-content: center;
   padding: 0 16px;
   cursor: pointer;
+`;
+
+const StyledIcon = styled(Icon)`
+  font-size: 0;
 `;
 
 const Text = styled.p`

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchDataset/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchDataset/index.tsx
@@ -113,7 +113,7 @@ const SwitchDataset: React.FC<BaseFieldProps<"switchDataset">> = ({
             getPopupContainer={trigger => trigger.parentElement ?? document.body}>
             <StyledDropdownButton>
               <p style={{ margin: 0 }}>{uiStyles[selectedStyle]}</p>
-              <Icon icon="arrowDownSimple" size={12} />
+              <StyledIcon icon="arrowDownSimple" size={12} />
             </StyledDropdownButton>
           </Dropdown>
         </FieldValue>
@@ -146,7 +146,7 @@ const SwitchDataset: React.FC<BaseFieldProps<"switchDataset">> = ({
                 getPopupContainer={trigger => trigger.parentElement ?? document.body}>
                 <StyledDropdownButton>
                   <p style={{ margin: 0 }}>{selectedDataset.name}</p>
-                  <Icon icon="arrowDownSimple" size={12} />
+                  <StyledIcon icon="arrowDownSimple" size={12} />
                 </StyledDropdownButton>
               </Dropdown>
             </FieldValue>
@@ -176,6 +176,10 @@ const StyledDropdownButton = styled.div`
   height: 32px;
   padding: 0 16px;
   cursor: pointer;
+`;
+
+const StyledIcon = styled(Icon)`
+  font-size: 0;
 `;
 
 const Field = styled.div<{ gap?: number }>`

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchGroup/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchGroup/index.tsx
@@ -94,7 +94,7 @@ const SwitchGroup: React.FC<BaseFieldProps<"switchGroup">> = ({
                   <p style={{ margin: 0 }}>
                     {fieldGroups?.find(fg => fg.id === g.fieldGroupID)?.name ?? "-"}
                   </p>
-                  <Icon icon="arrowDownSimple" size={12} />
+                  <StyledIcon icon="arrowDownSimple" size={12} />
                 </StyledDropdownButton>
               </Dropdown>
             </FieldValue>
@@ -121,7 +121,7 @@ const SwitchGroup: React.FC<BaseFieldProps<"switchGroup">> = ({
           <Dropdown overlay={uiMenu} placement="bottom" trigger={["click"]}>
             <StyledDropdownButton>
               <p style={{ margin: 0 }}>{currentGroup ? currentGroup.title : "-"}</p>
-              <Icon icon="arrowDownSimple" size={12} />
+              <StyledIcon icon="arrowDownSimple" size={12} />
             </StyledDropdownButton>
           </Dropdown>
         </FieldValue>
@@ -146,6 +146,10 @@ const StyledDropdownButton = styled.div`
   align-content: center;
   padding: 0 16px;
   cursor: pointer;
+`;
+
+const StyledIcon = styled(Icon)`
+  font-size: 0;
 `;
 
 const Text = styled.p`


### PR DESCRIPTION
## Overview

Set CSS style font size to 0 for dropdown icons to aviod the line height effects vertical alignment.

Fixes dropdown arrows in `switchDataset` `switchGroup` `legend` `legendGradient`

BEFORE:
![image](https://user-images.githubusercontent.com/21994748/229400361-4a16e42e-5cd6-4f53-be98-6f1e941c0c27.png)
![image](https://user-images.githubusercontent.com/21994748/229400509-27042433-3517-41be-aab4-3bd9c78c7390.png)

AFTER:
![image](https://user-images.githubusercontent.com/21994748/229400678-6963fb9b-25b5-4959-b8cd-13fc73540c09.png)
![image](https://user-images.githubusercontent.com/21994748/229400739-ba73ca8d-fe71-4f84-90c3-88357fba56f1.png)
