### PR TITLE
fix(plugin): unselect when switch current group or dataset

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchVisibility/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/Field/Fields/general/SwitchVisibility/index.tsx
@@ -101,10 +101,10 @@ const SwitchVisibility: React.FC<BaseFieldProps<"switchVisibility">> = ({
   );
 
   const handleSelectVisibility = (id: string) => {
-    setSelectedVisibility(id);
     postMsg({
       action: "unselect",
     });
+    setSelectedVisibility(id);
   };
 
   const visibilityOptions = (

--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
@@ -1,6 +1,6 @@
 import { mergeOverrides } from "@web/extensions/sidebar/core/components/utils";
 import { BuildingSearch, DataCatalogItem, Template } from "@web/extensions/sidebar/core/types";
-import { generateID, moveItemDown, moveItemUp } from "@web/extensions/sidebar/utils";
+import { generateID, moveItemDown, moveItemUp, postMsg } from "@web/extensions/sidebar/utils";
 import { getActiveFieldIDs } from "@web/extensions/sidebar/utils/dataset";
 import { useCallback, useEffect, useState } from "react";
 
@@ -48,6 +48,7 @@ export default ({
   const handleCurrentGroupUpdate = useCallback(
     (fieldGroupID?: string) => {
       if (fieldGroupID === dataset.selectedGroup) return;
+      postMsg({ action: "unselect" });
       onDatasetUpdate?.({
         ...dataset,
         selectedGroup: fieldGroupID,
@@ -59,6 +60,7 @@ export default ({
   const handleCurrentDatasetUpdate = useCallback(
     (selectedDataset?: ConfigData) => {
       if (selectedDataset === dataset.selectedDataset) return;
+      postMsg({ action: "unselect" });
       onDatasetUpdate?.({
         ...dataset,
         selectedDataset,


### PR DESCRIPTION
## Overview

The selection state of reearth will not be changed when user switch group or switch dataset. 
The previously selected entity might not be exists any more after the switch but if there was an infobox displayed the infobox will stay there.

Reorder the action in switchVisibility as well.

## Screen shot


https://user-images.githubusercontent.com/21994748/229417297-c5327ae8-4bdc-4c3f-8883-203a3b0b5d31.mp4

