### PR TITLE
fix(plugin): infinite loop on mobile

### DIFF
--- a/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/DatasetCard/hooks.ts
@@ -97,7 +97,7 @@ export default ({
 
   const handleFieldUpdate = useCallback(
     (id: string) => (property: any) => {
-      const newDatasetComponents = dataset.components ? [...dataset.components] : [];
+      const newDatasetComponents = [...(latestComponents.current ?? [])];
       const componentIndex = newDatasetComponents?.findIndex(c => c.id === id);
 
       if (!newDatasetComponents || componentIndex === undefined) return;
@@ -193,6 +193,10 @@ export default ({
     },
     [dataset, onDatasetUpdate],
   );
+
+  useEffect(() => {
+    latestComponents.current = dataset.components ?? [];
+  }, [dataset.components]);
 
   return {
     activeComponentIDs,

--- a/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/BuildingColor/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/BuildingColor/hooks.ts
@@ -100,8 +100,6 @@ const useHooks = ({
       setFloods(tempFloods);
     };
     const fetchTileset = async () => {
-      setInitialized(true);
-
       if (!url) {
         return;
       }

--- a/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/BuildingColor/index.tsx
+++ b/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/BuildingColor/index.tsx
@@ -134,7 +134,7 @@ const LegendList = styled.ul`
 const LegendItem = styled.li`
   display: flex;
   align-items: center;
-  list-item: none;
+  list-style: none;
 `;
 
 const ColorBlock = styled.div<{ color?: string }>`

--- a/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/BuildingShadow/useBuildingShadow.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/BuildingShadow/useBuildingShadow.ts
@@ -1,4 +1,4 @@
-import { RefObject, useCallback, useEffect, useRef } from "react";
+import { RefObject, useCallback, useEffect, useRef, MutableRefObject } from "react";
 
 import { BaseFieldProps } from "../../types";
 
@@ -14,6 +14,7 @@ export const useBuildingShadow = ({
   options: BaseFieldProps<"buildingShadow">["value"]["userSettings"];
   onUpdate: (property: any) => void;
 }) => {
+  const isInitializedRef = useRef(false);
   const onUpdateRef = useRef(onUpdate);
   useEffect(() => {
     onUpdateRef.current = onUpdate;
@@ -24,6 +25,7 @@ export const useBuildingShadow = ({
       {
         dataID,
         shadow: options.shadow,
+        isInitializedRef,
       },
       onUpdateRef,
     );
@@ -37,13 +39,18 @@ export const useBuildingShadow = ({
 export type State = {
   dataID: string | undefined;
   shadow: BaseFieldProps<"buildingShadow">["value"]["userSettings"]["shadow"];
+  isInitializedRef: MutableRefObject<boolean>;
 };
 
 const renderTileset = (state: State, onUpdateRef: RefObject<(property: any) => void>) => {
   const updateTileset = () => {
-    onUpdateRef.current?.({
-      shadows: state.shadow,
-    });
+    if (!state.isInitializedRef.current) {
+      state.isInitializedRef.current = true;
+    } else {
+      onUpdateRef.current?.({
+        shadows: state.shadow,
+      });
+    }
   };
   updateTileset();
 };

--- a/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/hooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/content/common/FieldComponent/Fields/3dtiles/hooks.ts
@@ -26,6 +26,7 @@ export const useObservingDataURL = (dataID: string | undefined) => {
 
     return () => {
       if (timeoutId) window.clearTimeout(timeoutId);
+      removeEventListener("message", waitReturnedPostMsg);
     };
   });
 

--- a/plugin/web/extensions/sidebar/core/components/mobile/hooks/index.ts
+++ b/plugin/web/extensions/sidebar/core/components/mobile/hooks/index.ts
@@ -187,7 +187,7 @@ export default () => {
   // Building Search
   const handleBuildingSearch = useCallback(
     (dataID: string) => {
-      const plateauItem = project.datasets.find(pd => pd.id === dataID);
+      const plateauItem = project.datasets.find(pd => pd.dataID === dataID);
       const searchIndex = plateauItem?.["search_index"];
       postMsg({
         action: "buildingSearchOpen",

--- a/plugin/web/extensions/sidebar/popups/mobileDropdown/index.tsx
+++ b/plugin/web/extensions/sidebar/popups/mobileDropdown/index.tsx
@@ -94,7 +94,8 @@ const MobileDropdown: React.FC = () => {
           if (e.data.payload.reearthURL) setReearthURL(e.data.payload.reearthURL);
           if (e.data.payload.backendURL) setBackendURL(e.data.payload.backendURL);
           if (e.data.payload.catalogURL) setCatalogURL(e.data.payload.catalogURL);
-          setCatalogProjectName(e.data.payload.catalogProjectName);
+          if (e.data.payload.catalogProjectName)
+            setCatalogProjectName(e.data.payload.catalogProjectName);
           if (e.data.payload.inEditor) setInEditor(e.data.payload.inEditor);
           if (e.data.payload.backendProjectName)
             setBackendProjectName(e.data.payload.backendProjectName);

--- a/plugin/web/extensions/sidebar/utils/overrides.ts
+++ b/plugin/web/extensions/sidebar/utils/overrides.ts
@@ -74,11 +74,14 @@ export const mergeOverrides = (
 
   const needOrderComponents = components
     .filter(c => (c as any).userSettings?.updatedAt)
-    .sort(
-      (a, b) =>
-        ((a as any).userSettings?.updatedAt?.getTime?.() ?? 0) -
-        ((b as any).userSettings?.updatedAt?.getTime?.() ?? 0),
-    );
+    .sort((a, b) => {
+      const ta = (a as any).userSettings?.updatedAt;
+      const tb = (b as any).userSettings?.updatedAt;
+      return (
+        ((typeof ta === "string" ? new Date(ta) : ta)?.getTime?.() ?? 0) -
+        ((typeof tb === "string" ? new Date(tb) : tb)?.getTime?.() ?? 0)
+      );
+    });
   for (const component of needOrderComponents) {
     merge(
       overrides,


### PR DESCRIPTION
## Overview

- Fix some filed component value can't be applied, or enter an apply-reset loop:
When on mobile, the `project` is not synced. Therefore the update of components can't get the updated values, when multiple filed components update triggerred, the out-of-date value could be carried and override the previous update.

- Fix infinite update:
switchDataset use `===` to check two objects, which could lead to infinite loop update.

- Fix overrides happen when initialization for `BuildingColor` `BuildingFilter` `BuildingShadow` `Clipping`.
- Fix override sort for `updateAt`, it could be string.
- Fix data catalog can't fetch data on switch tab.
- Fix an CSS property error.
- Fix mobile build search use wrong id.

## Test

Test project [here](https://test.reearth.dev/edit/01gxns5mw9axjt9q3sc2fajfnh).
