### PR TITLE
feat(plugin): building search always fly to the first match result

### DIFF
--- a/plugin/web/extensions/sidebar/popups/buildingSearch/components/hooks.ts
+++ b/plugin/web/extensions/sidebar/popups/buildingSearch/components/hooks.ts
@@ -291,7 +291,7 @@ export default () => {
   }, [selected]);
 
   useEffect(() => {
-    if (results.length === 1) {
+    if (results.length >= 1) {
       postMsg({
         action: "cameraLookAt",
         payload: [

--- a/plugin/web/extensions/sidebar/popups/buildingSearch/components/index.tsx
+++ b/plugin/web/extensions/sidebar/popups/buildingSearch/components/index.tsx
@@ -44,7 +44,7 @@ const BuildingSearch: React.FC = () => {
           </Button>
         </ButtonWrapper>
       </Header>
-      <MiniContent active={minimized} disabled={results.length === 0}>
+      <MiniContent active={minimized} disabled={results.length === 0} onClick={toggleMinimize}>
         {results.length === 0 ? `検索結果がありません` : `${results.length} 件が見つかりました`}
       </MiniContent>
       <Content active={!minimized}>
@@ -141,6 +141,7 @@ const MiniContent = styled.div<{ active: boolean; disabled: boolean }>`
   justify-content: center;
   font-size: 14px;
   color: ${({ disabled }) => (disabled ? "#bfbfbf" : "#000")};
+  cursor: pointer;
 `;
 
 const Content = styled.div<{ active: boolean }>`


### PR DESCRIPTION
## Overview

Small changes on building search to optimize UX:
- Always fly to the first result to make sure there's result shown in viewport.
- Make minipanel clickable.