### PR TITLE
fix(plugin): wrap the long titles for folders in datacatalog modal

### DIFF
--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/DatasetTree/Folder.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/DatasetTree/Folder.tsx
@@ -90,6 +90,7 @@ const Wrapper = styled.div<{ isOpen?: boolean }>`
       : `
   overflow: hidden;
   `}
+  min-height: 29px;
 `;
 
 const FolderItem = styled.div<{ nestLevel: number; selected?: boolean }>`
@@ -113,6 +114,7 @@ const FolderItem = styled.div<{ nestLevel: number; selected?: boolean }>`
     background: #00bebe;
     color: white;
   }
+  min-height: 29px;
 `;
 
 const NameWrapper = styled.div<{ isMobile?: boolean }>`

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/DatasetTree/Folder.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/DatasetTree/Folder.tsx
@@ -88,7 +88,6 @@ const Wrapper = styled.div<{ isOpen?: boolean }>`
     isOpen
       ? "height: 100%;"
       : `
-  height: 29px; 
   overflow: hidden;
   `}
 `;
@@ -99,8 +98,6 @@ const FolderItem = styled.div<{ nestLevel: number; selected?: boolean }>`
   justify-content: space-between;
   box-sizing: border-box;
   gap: 8px;
-  height: 29px;
-
   ${({ selected }) =>
     selected &&
     `
@@ -128,7 +125,4 @@ const NameWrapper = styled.div<{ isMobile?: boolean }>`
 const Name = styled.p`
   margin: 0;
   user-select: none;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
 `;


### PR DESCRIPTION
# Overview
 When opening datacatalog folder and open dataset page ,if the folder name is very long we need to wrpe in multiple lines
## Screenshot
![image](https://user-images.githubusercontent.com/89770889/232801722-7da3d1c0-bd12-4de8-8e32-da3d32aa4f6d.png)
test project : https://test.reearth.dev/edit/01gya8qmmaj6qzj1qksg6nf20x



