### PR TITLE
Fix typos: "トラッグ" → "ドラッグ"

### DIFF
--- a/plugin/web/extensions/sidebar/popups/help/BasicOperation/index.tsx
+++ b/plugin/web/extensions/sidebar/popups/help/BasicOperation/index.tsx
@@ -11,7 +11,7 @@ const BasicOperation: React.FC = () => {
           <ImgWrapper>
             <Icon icon="mouseMiddleButton" width={65} height={95} />
             <CaptionText>
-              トラッグ：視点移動
+              ドラッグ：視点移動
               <br />
               <br />
               回転：拡大縮小
@@ -19,11 +19,11 @@ const BasicOperation: React.FC = () => {
           </ImgWrapper>
           <ImgWrapper>
             <Icon icon="mouseLeftButton" width={65} height={95} />
-            <CaptionText>トラッグ：画面移動</CaptionText>
+            <CaptionText>ドラッグ：画面移動</CaptionText>
           </ImgWrapper>
           <ImgWrapper>
             <Icon icon="mouseRightButton" width={65} height={95} />
-            <CaptionText>トラッグ：拡大縮小</CaptionText>
+            <CaptionText>ドラッグ：拡大縮小</CaptionText>
           </ImgWrapper>
         </InstructionWrapper>
       </TopWrapper>


### PR DESCRIPTION
サイドメニューの「使い方」→「基本操作」にある説明ですが、誤字があるように思いました！

当PRで、3箇所の微修正を行なっています。

重複: [Fix typos: "トラッグ" → "ドラッグ" by sorami · Pull Request #1 · Project-PLATEAU/PLATEAU-VIEW-2.0](https://github.com/Project-PLATEAU/PLATEAU-VIEW-2.0/pull/1)

![image](https://user-images.githubusercontent.com/595008/233311705-91e6b942-b0e2-4ac9-a7ea-0128ed2c8419.png)
