### PR TITLE
fix(plugin): show catalog description

### DIFF
--- a/plugin/web/extensions/sidebar/modals/datacatalog/api/api.ts
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/api/api.ts
@@ -233,7 +233,12 @@ function sortByOrder(a: number | undefined, b: number | undefined): number {
 function filter(q: string | undefined, items: RawDataCatalogItem[]): RawDataCatalogItem[] {
   if (!q) return items;
   return items.filter(
-    i => i.name?.includes(q) || i.pref.includes(q) || i.city?.includes(q) || i.ward?.includes(q),
+    i =>
+      i.name?.includes(q) ||
+      i.pref.includes(q) ||
+      i.city?.includes(q) ||
+      i.ward?.includes(q) ||
+      i.type_en === "folder",
   );
 }
 

--- a/plugin/web/extensions/sidebar/modals/datacatalog/api/utils.ts
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/api/utils.ts
@@ -17,7 +17,8 @@ export function makeTree<
         if (!r.map[name]) {
           const list: R = { result: [], map: {} };
           r.map[name] = list;
-          const desc = items.find(i => i?.name === name && i.type_en === "folder")?.desc ?? "";
+          const desc =
+            items.find(i => i?.path.at(-1) === name && i.type_en === "folder")?.desc ?? "";
           const id = `node-${idCounter++}`;
           r.result.push({ id, name, desc, ...(last ? { item } : { children: list.result }) });
         }


### PR DESCRIPTION
# Overview:
This PR shows the catalog description correctly.

# What I've done:
I modified the folder description retrieval in `plugin/web/extensions/sidebar/modals/datacatalog/api/utils.ts` to ensure accurate descriptions are used when generating the tree.

# How I tested:
I have tested the changes by generating the data catalog tree and confirming that the folder descriptions are now correctly displayed. Additionally, I have tested with UI here [Test project](https://test.reearth.dev/edit/01gx0yyj0qt4p4wpmhzd6gs1b7) making sure the right description is shown.

# Screenshot
<img width="904" alt="Screenshot 2023-05-02 at 1 03 48 AM" src="https://user-images.githubusercontent.com/105633534/235539623-856eb98d-1208-42f6-b15f-d1b23072f4e1.png">

