### PR TITLE
fix(plugin): incorrect visibility and order of shared project's datasets

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -204,7 +204,7 @@ reearth.on("message", ({ action, payload }: PostMessageProps) => {
       const data = createLayer(payload.dataset, payload.overrides);
       console.log("DATA to add", data);
       const layerID = reearth.layers.add(data);
-      const idx = addedDatasets.push([payload.dataset.dataID, "showing", layerID]);
+      const idx = addedDatasets.push([payload.dataset.dataID, "showing", layerID]) - 1;
       if (!payload.dataset.visible) {
         reearth.layers.hide(addedDatasets[idx][2]);
         addedDatasets[idx][1] = "hidden";

--- a/plugin/web/extensions/sidebar/core/components/desktop/hooks/projectHooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/desktop/hooks/projectHooks.ts
@@ -320,7 +320,7 @@ export default ({
         if (res.status !== 200) return;
         const data = await res.json();
         if (data) {
-          (data.datasets as Data[]).forEach(d => {
+          (data.datasets as Data[]).reverse().forEach(d => {
             handleProjectDatasetAdd(d);
           });
           if (data.userStory?.scenes?.length > 0) {


### PR DESCRIPTION
## Overview

This PR fix:
1. Correct shared project's datasets' visibility.
2. Reverse shared project's datasets' order.