### PR TITLE
ci: refactor plugin-version-update

### DIFF
--- a/.github/workflows/ci-plugin-version-update.yml
+++ b/.github/workflows/ci-plugin-version-update.yml
@@ -20,8 +20,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Update version
         id: version
+        env:
+          COMMIT_SHA: ${{ github.event.inputs.commit-sha }}
         run: |
-          commit_message=$(git log --format=%B -n 1 ${{ github.event.inputs.commit-sha }})
+          commit_message=$(git log --format=%B -n 1 "$COMMIT_SHA")
           current_version=$(awk '/version: [0-9]+\.[0-9]+\.[0-9]+/{print $2}' plugin/public/reearth.yml)
           if [[ $commit_message == *"major"* ]]; then
             new_version=$(awk -F '.' '{print $1 "." $2+1".0"}' <<< $current_version)
@@ -37,4 +39,4 @@ jobs:
         run: |
           git add plugin/public/reearth.yml
           git commit -m "chore(plugin): update plugin version to v${{ steps.version.outputs.new_version }}"
-          git switch main && git push
+          git push


### PR DESCRIPTION
This PR refactor the `ci-plugin-version-update` workflow and is being used as dummy run for this workflow.