### PR TITLE
feat(plugin): detect position and set default marker for csv from my data

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -925,7 +925,7 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
       overrides?.infobox ?? {},
       infoboxGlobal,
     ),
-    ...(dataset.additionalData?.data?.csv?.latColume && dataset.additionalData?.data?.csv?.lngColumn
+    ...(dataset.additionalData?.data?.csv?.latColumn && dataset.additionalData?.data?.csv?.lngColumn
       ? { marker: defaultMarkerAppearanceForCSV }
       : {}),
     ...(overrides !== undefined

--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -925,7 +925,9 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
       overrides?.infobox ?? {},
       infoboxGlobal,
     ),
-    ...(dataset.additionalData?.marker ? { marker: dataset.additionalData.marker } : {}),
+    ...(dataset.additionalData?.data?.csv?.latColume && dataset.additionalData?.data?.csv?.lngColumn
+      ? { marker: defaultMarkerAppearanceForCSV }
+      : {}),
     ...(overrides !== undefined
       ? mergeDefaultOverrides(defaultOverrides, omit(overrides, ["data", "infobox"]), format)
       : format === "geojson" || format === "czml" || format === "gpx"
@@ -967,4 +969,10 @@ const defaultOverrides = {
   polyline: {
     clampToGround: true,
   },
+};
+
+const defaultMarkerAppearanceForCSV = {
+  style: "point",
+  pointSize: 10,
+  pointColor: "#FFFFFF",
 };

--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -884,6 +884,7 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
       (["tran", "usecase"].includes(dataset.type_en) && format === "mvt")
         ? { jsonProperties: ["attributes"] }
         : {}),
+      ...(dataset.additionalData?.data?.csv ? { csv: dataset.additionalData.data.csv } : {}),
       ...(overrides?.data || {}),
     },
     visible: true,
@@ -924,6 +925,7 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
       overrides?.infobox ?? {},
       infoboxGlobal,
     ),
+    ...(dataset.additionalData?.marker ? { marker: dataset.additionalData.marker } : {}),
     ...(overrides !== undefined
       ? mergeDefaultOverrides(defaultOverrides, omit(overrides, ["data", "infobox"]), format)
       : format === "geojson" || format === "czml" || format === "gpx"

--- a/plugin/web/extensions/sidebar/core/components/desktop/hooks/projectHooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/desktop/hooks/projectHooks.ts
@@ -317,21 +317,27 @@ export default ({
   );
 
   const fetchedSharedProject = useRef(false);
+  const fetchingSharedProject = useRef(false);
 
   useEffect(() => {
     if (
       (!isCustomProject && (!plateauBackendURL || !plateuProjectName)) ||
       (isCustomProject && (!customBackendURL || !customBackendProjectName)) ||
-      fetchedSharedProject.current
+      fetchedSharedProject.current ||
+      fetchingSharedProject.current
     )
       return;
 
     if (projectID) {
+      fetchingSharedProject.current = true;
       (async () => {
         const backendURL = isCustomProject ? customBackendURL : plateauBackendURL;
         const backendProjectName = isCustomProject ? customBackendProjectName : plateuProjectName;
         const res = await fetch(`${backendURL}/share/${backendProjectName}/${projectID}`);
-        if (res.status !== 200) return;
+        if (res.status !== 200) {
+          fetchingSharedProject.current = false;
+          return;
+        }
         const data = await res.json();
         if (data) {
           (data.datasets as Data[]).reverse().forEach(d => {
@@ -343,6 +349,7 @@ export default ({
           handleProjectSceneUpdate(data.sceneOverrides);
         }
         fetchedSharedProject.current = true;
+        fetchingSharedProject.current = false;
       })();
     }
   }, [

--- a/plugin/web/extensions/sidebar/core/types.ts
+++ b/plugin/web/extensions/sidebar/core/types.ts
@@ -17,7 +17,8 @@ export type DataCatalogGroup = {
   children: DataCatalogTreeItem[];
 };
 
-export type DataCatalogItem = RawDataCatalogItem & Data & { dataSource?: DataSource };
+export type DataCatalogItem = RawDataCatalogItem &
+  Data & { dataSource?: DataSource; additionalData?: AdditionalData };
 
 export type DataCatalogTreeItem = DataCatalogGroup | DataCatalogItem;
 
@@ -74,3 +75,16 @@ export type BuildingSearch = {
     updatedAt?: Date;
   };
 }[];
+
+// ****** Additional Data ******
+export type AdditionalData = {
+  data?: {
+    csv?: {
+      latColume?: string;
+      lngColumn?: string;
+      heightColumn?: string;
+      noHeader?: boolean;
+    };
+  };
+  marker?: any;
+};

--- a/plugin/web/extensions/sidebar/core/types.ts
+++ b/plugin/web/extensions/sidebar/core/types.ts
@@ -80,7 +80,7 @@ export type BuildingSearch = {
 export type AdditionalData = {
   data?: {
     csv?: {
-      latColume?: string;
+      latColumn?: string;
       lngColumn?: string;
       heightColumn?: string;
       noHeader?: boolean;

--- a/plugin/web/extensions/sidebar/core/types.ts
+++ b/plugin/web/extensions/sidebar/core/types.ts
@@ -86,5 +86,4 @@ export type AdditionalData = {
       noHeader?: boolean;
     };
   };
-  marker?: any;
 };

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
@@ -69,11 +69,6 @@ const LocalDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedLocalItem }) 
             noHeader: false,
           },
         },
-        marker: {
-          style: "point",
-          pointSize: 10,
-          pointColor: "#ff0000",
-        },
       };
     }
     return undefined;

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
@@ -69,7 +69,9 @@ const LocalDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedLocalItem }) 
             id: id,
             dataID: id,
             description: `このファイルは今お使いのWebブラウザでのみ閲覧可能です。共有URLを用いて共有するには、公開Webサーバー上のデータを読み込む必要があります。${
-              format === "csv" ? "<br/>" : ""
+              format === "csv"
+                ? "<br/><br/>パフォーマンス上の問題が発生するため、6000レコード以上を含むCSVファイルをアップロードしないでください。"
+                : ""
             }`,
             name: filename,
             visible: true,

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/LocalDataTab.tsx
@@ -7,6 +7,7 @@ import { RcFile } from "antd/lib/upload";
 import { useCallback, useMemo, useState } from "react";
 
 import FileTypeSelect, { fileFormats, FileType } from "./LocalFileTypeSelect";
+import { getAdditionalData } from "./utils";
 
 type Props = {
   onOpenDetails?: (data?: UserDataItem) => void;
@@ -45,35 +46,6 @@ const LocalDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedLocalItem }) 
     return type;
   }, []);
 
-  const getAdditionalData = useCallback((content: string | undefined, format: string) => {
-    if (!content) return undefined;
-    if (format === "csv") {
-      const header = content.split("\r\n")[0];
-      const cols = header.split(",");
-      const latColumn = cols.find(col =>
-        ["latitude", "lat", "緯度", "北緯"].includes(col.toLowerCase()),
-      );
-      const lngColumn = cols.find(col =>
-        ["longitude", "lng", "lon", "経度", "東経"].includes(col.toLowerCase()),
-      );
-      const heightColumn = cols.find(col =>
-        ["height", "altitude", "alt", "高度"].includes(col.toLowerCase()),
-      );
-      if (!latColumn || !lngColumn) return undefined;
-      return {
-        data: {
-          csv: {
-            latColumn,
-            lngColumn,
-            heightColumn,
-            noHeader: false,
-          },
-        },
-      };
-    }
-    return undefined;
-  }, []);
-
   const beforeUpload = useCallback(
     (file: RcFile, files: RcFile[]) => {
       const reader = new FileReader();
@@ -96,8 +68,9 @@ const LocalDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedLocalItem }) 
             type: "item",
             id: id,
             dataID: id,
-            description:
-              "このファイルは今お使いのWebブラウザでのみ閲覧可能です。共有URLを用いて共有するには、公開Webサーバー上のデータを読み込む必要があります。",
+            description: `このファイルは今お使いのWebブラウザでのみ閲覧可能です。共有URLを用いて共有するには、公開Webサーバー上のデータを読み込む必要があります。${
+              format === "csv" ? "<br/>" : ""
+            }`,
             name: filename,
             visible: true,
             url: url,
@@ -117,7 +90,7 @@ const LocalDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedLocalItem }) 
       setFileList([...files]);
       return false;
     },
-    [fileType, onOpenDetails, setDataFormat, setSelectedLocalItem, getAdditionalData],
+    [fileType, onOpenDetails, setDataFormat, setSelectedLocalItem],
   );
 
   const props: UploadProps = useMemo(

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/WebDataTab.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/WebDataTab.tsx
@@ -60,7 +60,9 @@ const WebDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedWebItem }) => {
       id: id,
       dataID: id,
       description: `著作権や制約に関する情報などの詳細については、このデータの提供者にお問い合わせください。${
-        format === "csv" ? "<br/>" : ""
+        format === "csv"
+          ? "<br/><br/>パフォーマンス上の問題が発生するため、6000レコード以上を含むCSVファイルをアップロードしないでください。"
+          : ""
       }`,
       name: filename,
       url: dataUrl,

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/WebDataTab.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/WebDataTab.tsx
@@ -36,6 +36,8 @@ const WebDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedWebItem }) => {
     return false;
   }, []);
 
+  const [isLoading, setLoading] = useState(false);
+
   const handleClick = useCallback(async () => {
     // Catalog Item
     const filename = dataUrl.substring(dataUrl.lastIndexOf("/") + 1);
@@ -44,11 +46,13 @@ const WebDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedWebItem }) => {
 
     let additionalData: AdditionalData | undefined;
     if (format === "csv") {
+      setLoading(true);
       const csv = await fetch(dataUrl);
       if (csv.status === 200) {
         const content = await csv.text();
         additionalData = getAdditionalData(content, format);
       }
+      setLoading(false);
     }
 
     const item: UserDataItem = {
@@ -92,7 +96,7 @@ const WebDataTab: React.FC<Props> = ({ onOpenDetails, setSelectedWebItem }) => {
         />
       </Form.Item>
       <Form.Item style={{ textAlign: "right" }}>
-        <Button type="primary" htmlType="submit" onClick={handleClick}>
+        <Button type="primary" htmlType="submit" onClick={handleClick} loading={isLoading}>
           データの閲覧
         </Button>
       </Form.Item>

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/utils.ts
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/YourDataPage/utils.ts
@@ -1,0 +1,28 @@
+export const getAdditionalData = (content: string | undefined, format: string) => {
+  if (!content) return undefined;
+  if (format === "csv") {
+    const header = content.split("\r\n")[0];
+    const cols = header.split(",");
+    const latColumn = cols.find(col =>
+      ["latitude", "lat", "緯度", "北緯"].includes(col.toLowerCase()),
+    );
+    const lngColumn = cols.find(col =>
+      ["longitude", "lng", "lon", "経度", "東経"].includes(col.toLowerCase()),
+    );
+    const heightColumn = cols.find(col =>
+      ["height", "altitude", "alt", "高度"].includes(col.toLowerCase()),
+    );
+    if (!latColumn || !lngColumn) return undefined;
+    return {
+      data: {
+        csv: {
+          latColumn,
+          lngColumn,
+          heightColumn,
+          noHeader: false,
+        },
+      },
+    };
+  }
+  return undefined;
+};

--- a/plugin/web/extensions/sidebar/modals/datacatalog/types.ts
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/types.ts
@@ -1,5 +1,8 @@
+import { AdditionalData } from "../../core/types";
+
 import { DataCatalogItem } from "./api/api";
 
 export type UserDataItem = Partial<DataCatalogItem> & {
   description?: string;
+  additionalData?: AdditionalData;
 };


### PR DESCRIPTION
## Overview

When user using My Data to upload a local csv file or load from an online csv url:
- system should detect the lat/lng/height by col name.
- system should set a default marker appearance for csv items if valid position col been found.

Basically this feature will be used in published page.

## What i have done

- Find the position columes with hard coded keywords:
  - latitude: `"latitude", "lat", "緯度", "北緯"`
  - longitude: `"longitude", "lng", "lon", "経度", "東経"`
  - height: `"height", "altitude", "alt", "高度"`
- Add default marker appearnce if lat & lng exists.
- Add `additionalData` to dataset and set override when createLayer
- Modify the text on detail panel of Mydata.
- Fix fetching project sometimes fetch twice bug.

## Test

Test with [this](https://test.reearth.dev/edit/01gtk2bjcpy103bep25kj4a2ve) project.