### PR TITLE
feat(plugin): display type name as infobox title instead of template name 

### DIFF
--- a/plugin/src/infobox.ts
+++ b/plugin/src/infobox.ts
@@ -53,8 +53,7 @@ reearth.on("pluginmessage", (pluginMessage: PluginMessage) => {
         action: "fillData",
         payload: {
           properties: reearth.layers.selectedFeature.properties,
-          template: pluginMessage.data.payload,
-          fldInfo: pluginMessage.data.payload?.fldInfo,
+          ...pluginMessage.data.payload,
         },
       });
     } else {

--- a/plugin/web/extensions/infobox/core/components/editPanel/index.tsx
+++ b/plugin/web/extensions/infobox/core/components/editPanel/index.tsx
@@ -9,6 +9,7 @@ import PropertyBrowser from "../common/PropertyBrowser";
 import FieldsEditor from "./FieldsEditor";
 
 type Props = {
+  name: string;
   properties?: Properties;
   fields: Field[];
   template: InfoboxTemplate;
@@ -25,7 +26,7 @@ type Props = {
 };
 
 const EditPanel: React.FC<Props> = ({
-  template,
+  name,
   fields,
   properties,
   isSaving,
@@ -50,7 +51,7 @@ const EditPanel: React.FC<Props> = ({
     <>
       <Header>
         <Tab active={editorTab === "view"} onClick={onTabView}>
-          {template.name}
+          {name}
         </Tab>
         <Tab active={editorTab === "edit"} onClick={onTabEdit}>
           <Icon icon="gearWheel" size={16} />

--- a/plugin/web/extensions/infobox/core/hooks.ts
+++ b/plugin/web/extensions/infobox/core/hooks.ts
@@ -11,6 +11,7 @@ export default () => {
   const [template, setTemplate] = useState<InfoboxTemplate | undefined>();
   const [fldInfo, setFldInfo] = useState<FldInfo | undefined>();
   const [properties, setProperties] = useState<Properties>();
+  const [displayTypeName, setDisplayTypeName] = useState<string>("");
 
   const [fields, setFields] = useState<Field[]>([]);
   const [editorTab, setEditorTab] = useState<EditorTab>("view");
@@ -114,7 +115,7 @@ export default () => {
         setTemplate(e.data.payload.template);
         setFldInfo(e.data.payload.fldInfo);
         setProperties(e.data.payload.properties);
-        setFldInfo(e.data.payload.fldInfo);
+        setDisplayTypeName(e.data.payload.displayTypeName ?? e.data.payload.template?.name ?? "");
         setDataState("ready");
         setEditorTab("view");
         break;
@@ -125,6 +126,7 @@ export default () => {
         setDataState("empty");
         setTemplate(undefined);
         setProperties({});
+        setDisplayTypeName("");
         break;
       case "saveFinish":
         setIsSaving(false);
@@ -189,6 +191,7 @@ export default () => {
     properties: actualProperties,
     fields,
     template,
+    displayTypeName,
     wrapperRef,
     isSaving,
     editorTab,

--- a/plugin/web/extensions/infobox/core/index.tsx
+++ b/plugin/web/extensions/infobox/core/index.tsx
@@ -12,6 +12,7 @@ const Infobox: React.FC = () => {
     properties,
     fields,
     template,
+    displayTypeName,
     wrapperRef,
     isSaving,
     editorTab,
@@ -32,6 +33,7 @@ const Infobox: React.FC = () => {
           {template &&
             (inEditor ? (
               <EditPanel
+                name={displayTypeName}
                 template={template}
                 fields={fields}
                 properties={properties}
@@ -48,7 +50,7 @@ const Infobox: React.FC = () => {
               />
             ) : (
               <ViewPanel
-                name={template.name}
+                name={displayTypeName}
                 fields={fields}
                 properties={properties}
                 commonProperties={commonProperties}

--- a/plugin/web/extensions/sidebar/core/components/desktop/hooks/projectHooks.ts
+++ b/plugin/web/extensions/sidebar/core/components/desktop/hooks/projectHooks.ts
@@ -9,7 +9,7 @@ import {
 import { getActiveFieldIDs, processDatasetToAdd } from "@web/extensions/sidebar/utils/dataset";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { BuildingSearch, Data, DataCatalogItem, FldInfo, Template } from "../../../types";
+import { BuildingSearch, Data, DataCatalogItem, Template } from "../../../types";
 import {
   StoryItem,
   Story as FieldStory,
@@ -287,12 +287,12 @@ export default ({
 
   const handleInfoboxFieldsFetch = useCallback(
     (dataID: string) => {
-      let fields: (Template & { fldInfo?: FldInfo }) | undefined;
+      let template: Template | undefined;
       const catalogItem = project.datasets?.find(d => d.dataID === dataID);
       if (catalogItem) {
         const name = catalogItem.type;
         const dataType = catalogItem.type_en;
-        fields = infoboxTemplates?.find(
+        template = infoboxTemplates?.find(
           ft => ft.type === "infobox" && ft.dataType === dataType,
         ) ?? {
           id: "",
@@ -301,16 +301,18 @@ export default ({
           dataType,
           fields: [],
         };
-
-        fields.fldInfo = {
-          name: catalogItem.name,
-          datasetName: catalogItem.selectedDataset?.name,
-        };
       }
 
       postMsg({
         action: "infoboxFieldsFetch",
-        payload: fields,
+        payload: {
+          template,
+          fldInfo: {
+            name: catalogItem?.name,
+            datasetName: catalogItem?.selectedDataset?.name,
+          },
+          displayTypeName: catalogItem?.type,
+        },
       });
     },
     [project.datasets, infoboxTemplates],


### PR DESCRIPTION
## Overview

Dataset's `type` and `type_en` is no longer one-to-one pair from data. 
Perticually `type` 建築物モデル and 建築物・橋梁モデル share the same `type_en` as `bldg`.

Therefore we should use dataset's type name as the infobox title instead of the template name.

Note: `type_en` is the actual key for infobox field template.

## Test

Test project [here](https://test.reearth.dev/edit/01gtk2bjcpy103bep25kj4a2ve).