### PR TITLE
feat(plugin): replace unknown date in feature attributes

### DIFF
--- a/plugin/web/extensions/infobox/core/components/common/PropertyBrowser.tsx
+++ b/plugin/web/extensions/infobox/core/components/common/PropertyBrowser.tsx
@@ -1,8 +1,10 @@
 import { cesium3DTilesAppearanceKeys } from "@web/extensions/infobox/core/utils";
 import type { Properties, Field } from "@web/extensions/infobox/types";
 import { styled } from "@web/theme";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import ReactJson from "react-json-view";
+
+import { replaceUnknownDate } from "../../utils";
 
 type DisplayItem = {
   path: string;
@@ -77,6 +79,15 @@ const PropertyBrowser: React.FC<Props> = ({
     setDisplayList(items);
   }, [fields, properties, commonProperties, attributesKey]);
 
+  const processedRawAttributes: JSON | undefined = useMemo(() => {
+    if (!attributesKey || !properties?.[attributesKey]) return undefined;
+    try {
+      return replaceUnknownDate(properties[attributesKey]);
+    } catch (error) {
+      return properties[attributesKey];
+    }
+  }, [properties, attributesKey]);
+
   return (
     <Wrapper>
       {displayList.map(field => (
@@ -85,10 +96,10 @@ const PropertyBrowser: React.FC<Props> = ({
           <Value>{field.value}</Value>
         </PropertyItem>
       ))}
-      {attributesKey && (
+      {processedRawAttributes && (
         <AttributesWrapper>
           <ReactJson
-            src={properties?.[attributesKey]}
+            src={processedRawAttributes}
             displayDataTypes={false}
             enableClipboard={false}
             displayObjectSize={false}

--- a/plugin/web/extensions/infobox/core/utils/clearfyDate.test.ts
+++ b/plugin/web/extensions/infobox/core/utils/clearfyDate.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "vitest";
+
+import { replaceUnknownDate } from "./clearfyDate";
+import type { Json } from "./json";
+
+test("replaceUnknownDate", () => {
+  const src: Json = {
+    a: "0001-01-01",
+    b: {
+      c: "0001-01-01",
+      d: {
+        e: "0001-01-01",
+        f: "fff",
+      },
+    },
+  };
+  const actual = replaceUnknownDate(src);
+  expect(actual).toEqual({
+    a: "不明",
+    b: {
+      c: "不明",
+      d: {
+        e: "不明",
+        f: "fff",
+      },
+    },
+  });
+});

--- a/plugin/web/extensions/infobox/core/utils/clearfyDate.ts
+++ b/plugin/web/extensions/infobox/core/utils/clearfyDate.ts
@@ -1,0 +1,20 @@
+import { Json } from "./json";
+
+function walkForDate(obj: any) {
+  if (!obj || typeof obj !== "object") return;
+  for (const key in obj) {
+    if (obj[key] === "0001-01-01") {
+      obj[key] = "不明";
+      continue;
+    }
+    if (typeof obj[key] === "object" && obj[key] !== null) {
+      walkForDate(obj[key]);
+    }
+  }
+  return obj;
+}
+
+export function replaceUnknownDate(attributes: Json): Json {
+  if (!attributes) return attributes;
+  return walkForDate(attributes);
+}

--- a/plugin/web/extensions/infobox/core/utils/index.ts
+++ b/plugin/web/extensions/infobox/core/utils/index.ts
@@ -1,6 +1,7 @@
 import { ActionType } from "../../types";
 
 export { getAttributes, getRootFields, commonPropertiesMap } from "./attributes";
+export { replaceUnknownDate } from "./clearfyDate";
 
 export function postMsg(action: ActionType, payload?: any) {
   if (parent === window) return;


### PR DESCRIPTION
## Overview

`0001-01-01` is used for present unknown in some attributes, we need to display `不明` instead of the dummy date.

Note: only replace `0001-01-01` for now, we should not replace the value too generic like `01` since it could be some meaningful value.

Before | After
----- | -----
![image](https://github.com/eukarya-inc/reearth-plateauview/assets/21994748/03c58d8f-0539-4ab3-bb2d-062da17963b5)| ![image](https://github.com/eukarya-inc/reearth-plateauview/assets/21994748/f4637505-074a-4ecc-95e7-c6d65875b4ce)



## Test

Test project [here](https://test.reearth.dev/edit/01gtk2bjcpy103bep25kj4a2ve).
Test with these datasets:
- **区域区分モデル（横浜市）**
- **用途地域モデル（横浜市）**

