### PR TITLE
feat(plugin): hide g-space link for datasets of local city

### DIFF
--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/Details.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/Details.tsx
@@ -3,6 +3,7 @@ import DetailsComponent from "@web/extensions/sidebar/modals/datacatalog/compone
 import { Icon } from "@web/sharedComponents";
 import { styled } from "@web/theme";
 
+import { DataSource } from "../../../api/api";
 import { UserDataItem } from "../../../types";
 
 import { Tag as TagType } from "./Tags";
@@ -15,6 +16,7 @@ export type Props = {
   isMobile?: boolean;
   inEditor?: boolean;
   editable?: boolean;
+  dataSource: DataSource;
   addDisabled: (dataID: string) => boolean;
   onTagSelect?: (tag: TagType) => void;
   onDatasetAdd: (dataset: DataCatalogItem | UserDataItem, keepModalOpen?: boolean) => void;
@@ -27,6 +29,7 @@ const DatasetDetails: React.FC<Props> = ({
   inEditor,
   addDisabled,
   editable,
+  dataSource,
   // onTagSelect,
   onDatasetAdd,
   onDatasetPublish,
@@ -77,13 +80,15 @@ const DatasetDetails: React.FC<Props> = ({
         <br />
         <StyledP>データセットを選択してください</StyledP>
       </NoDataMain>
-      <NoDataFooter
-        onClick={() =>
-          window.open("https://www.geospatial.jp/ckan/dataset/plateau-tokyo23ku", "_blank")
-        }>
-        <Icon icon="newPage" size={16} />
-        <StyledP> オープンデータ・ダウンロード(G空間情報センターへのリンク)</StyledP>
-      </NoDataFooter>
+      {dataSource === "plateau" && (
+        <NoDataFooter
+          onClick={() =>
+            window.open("https://www.geospatial.jp/ckan/dataset/plateau-tokyo23ku", "_blank")
+          }>
+          <Icon icon="newPage" size={16} />
+          <StyledP> オープンデータ・ダウンロード(G空間情報センターへのリンク)</StyledP>
+        </NoDataFooter>
+      )}
     </NoData>
   );
 };

--- a/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/index.tsx
+++ b/plugin/web/extensions/sidebar/modals/datacatalog/components/content/DatasetsPage/index.tsx
@@ -94,6 +94,7 @@ const DatasetsPage: React.FC<Props> = ({
           dataset={selectedDataset}
           inEditor={inEditor}
           editable={editable}
+          dataSource={dataSource}
           addDisabled={addDisabled}
           onTagSelect={handleTagSelect}
           onDatasetAdd={onDatasetAdd}

--- a/plugin/web/extensions/sidebar/popups/mobileDropdown/Catalog/index.tsx
+++ b/plugin/web/extensions/sidebar/popups/mobileDropdown/Catalog/index.tsx
@@ -314,6 +314,7 @@ const Catalog: React.FC<Props> = ({
           <DatasetDetails
             dataset={selectedDataset}
             isMobile={isMobile}
+            dataSource={selectedDataset?.dataSource ?? "plateau"}
             addDisabled={addDisabled}
             onDatasetAdd={onDatasetAdd}
           />


### PR DESCRIPTION
## Overview

Hide the g-space link from dataset detail page when it's a dataset of local city.

| Local dataset      | Plateau dataset |
| ----------- | ----------- |
| ![image](https://github.com/eukarya-inc/reearth-plateauview/assets/21994748/a22bc4c8-0b1d-46e1-b4fc-1acf45342bdf)      | ![image](https://github.com/eukarya-inc/reearth-plateauview/assets/21994748/d5dfc241-53e4-441a-b487-2b251ea0c567)       |
