### PR TITLE
fix(plugin): support datatype gen for infobox

### DIFF
--- a/plugin/src/sidebar.ts
+++ b/plugin/src/sidebar.ts
@@ -883,7 +883,7 @@ function createLayer(dataset: DataCatalogItem, overrides?: any) {
       layers,
       ...(format === "wms" ? { parameters: { transparent: "true", format: "image/png" } } : {}),
       ...(["luse", "lsld", "urf", "rail", "wwy", "area"].includes(dataset.type_en) ||
-      (["tran", "usecase"].includes(dataset.type_en) && format === "mvt")
+      (["tran", "usecase", "gen"].includes(dataset.type_en) && format === "mvt")
         ? { jsonProperties: ["attributes"] }
         : {}),
       ...(dataset.additionalData?.data?.csv ? { csv: dataset.additionalData.data.csv } : {}),

--- a/plugin/web/extensions/infobox/core/hooks.ts
+++ b/plugin/web/extensions/infobox/core/hooks.ts
@@ -26,7 +26,7 @@ export default () => {
 
   useEffect(() => {
     const fieldItems: Field[] = [];
-    const commonProperties = template?.dataType ? commonPropertiesMap[template.dataType] : [];
+    const commonProperties = template?.dataType ? commonPropertiesMap[template.dataType] ?? [] : [];
     setCommonProperties(commonProperties);
 
     // show fields with default order if no settings

--- a/plugin/web/extensions/infobox/core/utils/attributes.ts
+++ b/plugin/web/extensions/infobox/core/utils/attributes.ts
@@ -315,4 +315,6 @@ export const commonPropertiesMap: { [key: string]: string[] } = {
   wwy: ["gml_id"],
   // 区域モデル
   area: ["gml_id"],
+  // 汎用都市オブジェクトモデル
+  gen: ["gml_id"],
 };


### PR DESCRIPTION
## Overview

- Add a fallback `?? []` in case there's any new type that didn't exists in `commonPropertiesMap`.
- Add type support for `gen`